### PR TITLE
Fixed bug which was causing an unwanted "a" key event.

### DIFF
--- a/platform/mac/GLView.mm
+++ b/platform/mac/GLView.mm
@@ -1017,14 +1017,18 @@ static U32 *sTouchId = (U32*)(& kTapTolerance); // any arbitrary pointer value w
 {
     unsigned long mask = [MacKeyServices getModifierMaskForKey:[event keyCode]];
 
-    // The mask contains a few bits set. All must be set to consider the key down.
-    if ( ( [event modifierFlags] & mask ) == mask )
+    // After certain actions, like using the screenshot tool, MacOS apparently triggers the "a" key event. Can't imagine anyone would like this event.
+    if ( [event keyCode] != kVK_ANSI_A )
     {
-        [self keyDown:event];
-    }
-    else
-    {
-        [self keyUp:event];
+        // The mask contains a few bits set. All must be set to consider the key down.
+        if ( ( [event modifierFlags] & mask ) == mask)
+        {
+            [self keyDown:event];
+        }
+        else
+        {
+            [self keyUp:event];
+        }
     }
 }
 


### PR DESCRIPTION
This bug happened when using the screenshot tool in MacOS. Simply handled it by just ignoring the event when the keyCode = kVK_ANSI_A because this shouldn't even happen in the 'flagsChanged' method.

Steps to reproduce the original bug: Simply add a "key" listener in the main.lua and print the keyName & phase. Start the simulator and create a screenshot with "cmd + shift + 4". Runtime:addEventListener("key", function(event) print(event.keyName, event.phase) end)