### PR TITLE
Made SpriteObject functions overridable, just like DisplayObject functions

### DIFF
--- a/librtt/Rtt_LuaProxyVTable.cpp
+++ b/librtt/Rtt_LuaProxyVTable.cpp
@@ -4759,15 +4759,9 @@ LuaSpriteObjectProxyVTable::SetValueForKey( lua_State *L, MLuaProxyable& object,
 		"numFrames",	// 2
 		"isPlaying",	// 3
 		"sequence",		// 4
-
-		// Methods
-		"play",			// 5
-		"pause",		// 6
-		"setSequence",	// 7
-		"setFrame",		// 8
 	};
 	static const int numKeys = sizeof( keys ) / sizeof( const char * );
-	static StringHash sHash( *LuaContext::GetAllocator( L ), keys, numKeys, 9, 0, 7, __FILE__, __LINE__ );
+	static StringHash sHash( *LuaContext::GetAllocator( L ), keys, numKeys, 5, 1, 1, __FILE__, __LINE__ );
 	StringHash *hash = &sHash;
 
 	int index = hash->Lookup( key );

--- a/librtt/Rtt_LuaProxyVTable.cpp
+++ b/librtt/Rtt_LuaProxyVTable.cpp
@@ -4797,10 +4797,6 @@ LuaSpriteObjectProxyVTable::SetValueForKey( lua_State *L, MLuaProxyable& object,
 	case 2:
 	case 3:
 	case 4:
-	case 5:
-	case 6:
-	case 7:
-	case 8:
 		{
 			// Read-only properties
 			// no-op


### PR DESCRIPTION
SpriteObjects functions (setSequence, setFrame, play, pause) where made read-only. This doesn't match the behaviour of DisplayObject functions and limits customisability for the user.

Below is some code to test this behavior, just needs a `local createdSprite = display.newSprite()` call

```
local initialSetSequenceFunction = createdSprite.setSequence
createdSprite.setSequence = function() end
print(initialSetSequenceFunction == createdSprite.setSequence) -- prints false

local initialScaleFunction = createdSprite.scale
createdSprite.scale = function() end
print(initialScaleFunction == createdSprite.scale) -- prints true
```