### PR TITLE
Fixed SpriteObject::SetFrame for when sprite is not playing

### DIFF
--- a/librtt/Display/Rtt_SpriteObject.cpp
+++ b/librtt/Display/Rtt_SpriteObject.cpp
@@ -1114,8 +1114,15 @@ SpriteObject::SetFrame( int index )
 				playTime = Rtt_RealDiv( playTime, fTimeScale );
 			}
 
-			U64 curTime = fPlayer.GetAnimationTime();
-			fStartTime = curTime - Rtt_RealToInt( playTime );
+			if ( !IsPlaying() )
+			{
+				fPlayTime = Rtt_RealToInt( playTime );
+			}
+			else
+			{
+				U64 curTime = fPlayer.GetAnimationTime();
+				fStartTime = curTime - Rtt_RealToInt( playTime );
+			}
 		}
 
 		fCurrentFrame = index;


### PR DESCRIPTION
SetFrame() in Rtt_SpriteObject now sets fPlayTime if it's not playing, and fStartTime when it is.

Previously it always just set fStartTime, that caused the sprite to glitch when there's a delay between SetFrame() and Play() executions.

Code to cause the initial bug:
```
local sprite = createSpriteWith1000msPlaytime()
sprite:setFrame(1)

timer.performWithDelay(2000, function()
   sprite:play()
end)
```


 
