### PR TITLE
add xDelta & yDelta properties to touch events

### DIFF
--- a/librtt/Rtt_Event.cpp
+++ b/librtt/Rtt_Event.cpp
@@ -1998,7 +1998,9 @@ TouchEvent::TouchEvent()
 	fYStartScreen( Rtt_REAL_0 ),
 	fXStartContent( Rtt_REAL_0 ),
 	fYStartContent( Rtt_REAL_0 ),
-	fPressure( kPressureInvalid )
+	fPressure( kPressureInvalid ),
+    fDeltaX( Rtt_REAL_0 ),
+    fDeltaY( Rtt_REAL_0 )
 {
 }
 
@@ -2010,7 +2012,9 @@ TouchEvent::TouchEvent( Real x, Real y, Real xStartScreen, Real yStartScreen, Ph
 	fYStartScreen( yStartScreen ),
 	fXStartContent( xStartScreen ),
 	fYStartContent( yStartScreen ),
-	fPressure( pressure )
+	fPressure( pressure ),
+    fDeltaX( x - xStartScreen ),
+    fDeltaY( y - yStartScreen )
 {
 }
 
@@ -2030,6 +2034,8 @@ TouchEvent::Push( lua_State *L ) const
 		const char kXStartKey[] = "xStart";
 		const char kYStartKey[] = "yStart";
 		const char kPressureKey[] = "pressure";
+        const char kXDeltaKey[] = "xDelta";
+        const char kYDeltaKey[] = "yDelta";
 
 		lua_pushstring( L, StringForPhase( (Phase)fPhase ) );
 		lua_setfield( L, -2, kPhaseKey );
@@ -2038,6 +2044,10 @@ TouchEvent::Push( lua_State *L ) const
 		lua_setfield( L, -2, kXStartKey );
 		lua_pushnumber( L, Rtt_RealToFloat( fYStartContent ) );
 		lua_setfield( L, -2, kYStartKey );
+        lua_pushinteger( L, Rtt_RealToInt( fDeltaX) );
+        lua_setfield( L, -2, kXDeltaKey );
+        lua_pushinteger( L, Rtt_RealToInt( fDeltaY ));
+        lua_setfield( L, -2, kYDeltaKey );
 		
 		if ( fPressure >= kPressureThreshold )
 		{

--- a/librtt/Rtt_Event.cpp
+++ b/librtt/Rtt_Event.cpp
@@ -1999,8 +1999,8 @@ TouchEvent::TouchEvent()
 	fXStartContent( Rtt_REAL_0 ),
 	fYStartContent( Rtt_REAL_0 ),
 	fPressure( kPressureInvalid ),
-    fDeltaX( Rtt_REAL_0 ),
-    fDeltaY( Rtt_REAL_0 )
+	fDeltaX( Rtt_REAL_0 ),
+	fDeltaY( Rtt_REAL_0 )
 {
 }
 
@@ -2013,8 +2013,8 @@ TouchEvent::TouchEvent( Real x, Real y, Real xStartScreen, Real yStartScreen, Ph
 	fXStartContent( xStartScreen ),
 	fYStartContent( yStartScreen ),
 	fPressure( pressure ),
-    fDeltaX( x - xStartScreen ),
-    fDeltaY( y - yStartScreen )
+	fDeltaX( x - xStartScreen ),
+	fDeltaY( y - yStartScreen )
 {
 }
 
@@ -2034,8 +2034,8 @@ TouchEvent::Push( lua_State *L ) const
 		const char kXStartKey[] = "xStart";
 		const char kYStartKey[] = "yStart";
 		const char kPressureKey[] = "pressure";
-        const char kXDeltaKey[] = "xDelta";
-        const char kYDeltaKey[] = "yDelta";
+		const char kXDeltaKey[] = "xDelta";
+		const char kYDeltaKey[] = "yDelta";
 
 		lua_pushstring( L, StringForPhase( (Phase)fPhase ) );
 		lua_setfield( L, -2, kPhaseKey );
@@ -2044,10 +2044,10 @@ TouchEvent::Push( lua_State *L ) const
 		lua_setfield( L, -2, kXStartKey );
 		lua_pushnumber( L, Rtt_RealToFloat( fYStartContent ) );
 		lua_setfield( L, -2, kYStartKey );
-        lua_pushinteger( L, Rtt_RealToInt( fDeltaX) );
-        lua_setfield( L, -2, kXDeltaKey );
-        lua_pushinteger( L, Rtt_RealToInt( fDeltaY ));
-        lua_setfield( L, -2, kYDeltaKey );
+		lua_pushinteger( L, Rtt_RealToInt( fDeltaX) );
+		lua_setfield( L, -2, kXDeltaKey );
+		lua_pushinteger( L, Rtt_RealToInt( fDeltaY ));
+		lua_setfield( L, -2, kYDeltaKey );
 		
 		if ( fPressure >= kPressureThreshold )
 		{

--- a/librtt/Rtt_Event.h
+++ b/librtt/Rtt_Event.h
@@ -913,8 +913,8 @@ class TouchEvent : public HitEvent
 	public:
 		bool IsProperty( U16 mask ) const { return (fProperties & mask) != 0; }
 		void SetProperty( U16 mask, bool value );
-    Rtt_FORCE_INLINE Real DeltaX() const { return fDeltaX; };
-    Rtt_FORCE_INLINE Real DeltaY() const { return fDeltaY; };
+		Rtt_FORCE_INLINE Real DeltaX() const { return fDeltaX; };
+		Rtt_FORCE_INLINE Real DeltaY() const { return fDeltaY; };
 
 	private:
 		U16 fPhase;
@@ -924,8 +924,8 @@ class TouchEvent : public HitEvent
 		mutable Real fXStartContent;
 		mutable Real fYStartContent;
 		Real fPressure;
-        Real fDeltaX;
-        Real fDeltaY;
+		Real fDeltaX;
+		Real fDeltaY;
 };
 
 // ----------------------------------------------------------------------------

--- a/librtt/Rtt_Event.h
+++ b/librtt/Rtt_Event.h
@@ -913,6 +913,8 @@ class TouchEvent : public HitEvent
 	public:
 		bool IsProperty( U16 mask ) const { return (fProperties & mask) != 0; }
 		void SetProperty( U16 mask, bool value );
+    Rtt_FORCE_INLINE Real DeltaX() const { return fDeltaX; };
+    Rtt_FORCE_INLINE Real DeltaY() const { return fDeltaY; };
 
 	private:
 		U16 fPhase;
@@ -922,6 +924,8 @@ class TouchEvent : public HitEvent
 		mutable Real fXStartContent;
 		mutable Real fYStartContent;
 		Real fPressure;
+        Real fDeltaX;
+        Real fDeltaY;
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This commit modifies "touch" events so that the event table dispatched now includes "xDelta" and "yDelta" properties, indicating the difference between the touch's current X/Y values and the "xStart" and "yStart" values.

Added as a convenience so that developers won't have to perform these calculations in their touch listeners.

More-or-less copied from the undocumented Runtime "drag" event.