### PR TITLE
Fixed a bug in SpriteObject -> GetFrameIndexForDeltaTime()

### DIFF
--- a/librtt/Display/Rtt_SpriteObject.cpp
+++ b/librtt/Display/Rtt_SpriteObject.cpp
@@ -779,7 +779,9 @@ SpriteObject::GetFrameIndexForDeltaTime( Real dt, SpriteObjectSequence *sequence
 	{
 		int numFrames = sequence->GetNumFrames();
 		Real *timeArray = sequence->GetTimeArray();
-		for (int i = fTimeArrayCachedFrame; i < effectiveNumFrames; ++i) // Increase cachedFrame until dt is lower than cachedNextFrameTime again
+		
+		// Increase cachedFrame until dt is lower than cachedNextFrameTime again OR effectiveNumFrames is reached when using finite loops
+		for (int i = fTimeArrayCachedFrame; (0 == sequence->GetLoopCount() && dt > fTimeArrayCachedNextFrameTime) || i < effectiveNumFrames; ++i)
 		{
 			fTimeArrayCachedFrame += 1;
 			


### PR DESCRIPTION
When a frame takes longer than the duration of a full infinite loop sequence, sprites would get stuck.
I modified the for loop to keep iterating until deltaTime is bigger than fTimeArrayCachedNextFrameTime again.
This will also give it a more consistent result, since it can now return an index higher then effectiveNumFrames (same as when not using a 'time' array)