### PR TITLE
Added initialSystemUiVisibility property to 'android' key in build.settings

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/Controller.java
+++ b/platform/android/sdk/src/com/ansca/corona/Controller.java
@@ -2028,7 +2028,8 @@ public class Controller {
 						// 0x00001000 View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY lets touch events pass to the corona app
 						// 0x00000002 View.SYSTEM_UI_FLAG_HIDE_NAVIGATION hides any on screen navigation buttons
 						// 0x00000004 View.SYSTEM_UI_FLAG_FULLSCREEN hides the status bar
-						vis = 0x00001000 | 0x00000002 | 0x00000004;
+						// 0x00000200 View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION avoids resize event
+						vis = 0x00001000 | 0x00000002 | 0x00000004 | 0x00000200;
 				} else if (visibility.equals("immersive") && (
 					(android.os.Build.VERSION.SDK_INT >= 19) ||
 					(android.os.Build.MANUFACTURER.equals("Amazon") && android.os.Build.VERSION.SDK_INT >= 14))) {
@@ -2037,7 +2038,8 @@ public class Controller {
 						// 0x00000800 View.SYSTEM_UI_FLAG_IMMERSIVE lets touch events pass to the corona app
 						// 0x00000002 View.SYSTEM_UI_FLAG_HIDE_NAVIGATION hides any on screen navigation buttons
 						// 0x00000004 View.SYSTEM_UI_FLAG_FULLSCREEN hides the status bar
-						vis = 0x00000800 | 0x00000002 | 0x00000004;
+						// 0x00000200 View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION avoids resize event
+						vis = 0x00000800 | 0x00000002 | 0x00000004 | 0x00000200;
 				} else if (visibility.equals("lowProfile")) {
 					// On API Level 14 and above: View.SYSTEM_UI_FLAG_LOW_PROFILE dims any on screen buttons if they exists
 					// For API Level 11 - 13: View.STATUS_BAR_HIDDEN has the same effect

--- a/platform/android/sdk/src/com/ansca/corona/CoronaActivity.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaActivity.java
@@ -32,6 +32,7 @@ import android.app.UiModeManager;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.animation.AlphaAnimation;
@@ -263,6 +264,26 @@ public class CoronaActivity extends Activity {
 
 		// Create our CoronaRuntime, which also initializes the native side of the CoronaRuntime.
 		fCoronaRuntime = new CoronaRuntime(this, false);
+
+		// Set initialSystemUiVisibility before splashScreen comes up
+		try {
+			android.content.pm.ActivityInfo activityInfo;
+			activityInfo = getPackageManager().getActivityInfo(getComponentName(), android.content.pm.PackageManager.GET_META_DATA);
+			if ((activityInfo != null) && (activityInfo.metaData != null)) {
+				String initialSystemUiVisibility = activityInfo.metaData.getString("initialSystemUiVisibility");
+				if (initialSystemUiVisibility != null) {
+					if (initialSystemUiVisibility.equals("immersiveSticky") && Build.VERSION.SDK_INT < 19) {
+						fCoronaRuntime.getController().setSystemUiVisibility("lowProfile");
+					} else {
+						fCoronaRuntime.getController().setSystemUiVisibility(initialSystemUiVisibility);
+					}
+				}
+			}
+		}
+		catch (Exception ex) {
+			ex.printStackTrace();
+		}
+
 		// fCoronaRuntime = new CoronaRuntime(this, false);		// for Tegra debugging
 
 		showCoronaSplashScreen();

--- a/platform/android/template/AndroidManifest.template.xml
+++ b/platform/android/template/AndroidManifest.template.xml
@@ -38,6 +38,7 @@
 				  android:launchMode="singleTask"
 		          android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
 			@USER_CORONA_WINDOW_MOVES_WHEN_KEYBOARD_APPEARS@
+			@USER_INITIAL_SYSTEM_UI_VISIBILITY@
 			@USER_REQUESTED_DEFAULT_ORIENTATION@
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />

--- a/platform/android/template/AndroidManifest.xml
+++ b/platform/android/template/AndroidManifest.xml
@@ -53,6 +53,7 @@
 				  @USER_CORONA_ACTIVITY_ATTRIBUTES@
 		          android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
 			@USER_CORONA_WINDOW_MOVES_WHEN_KEYBOARD_APPEARS@
+			@USER_INITIAL_SYSTEM_UI_VISIBILITY@
 			@USER_REQUESTED_DEFAULT_ORIENTATION@
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />

--- a/platform/android/template/update_manifest.lua
+++ b/platform/android/template/update_manifest.lua
@@ -95,6 +95,7 @@ local applicationChildXmlElements = {}
 local googlePlayGamesAppId = false
 local facebookAppId = false
 local coronaWindowMovesWhenKeyboardAppears = false
+local initialSystemUiVisibility = nil
 local allowAppsReadOnlyAccessToFiles = true
 local strings = {}
 local apkFiles = { "...NONE..." } -- necessary due to the way ant treats empty filelists
@@ -522,6 +523,11 @@ if "table" == type(buildSettings) then
 			coronaWindowMovesWhenKeyboardAppears = buildSettings.android.CoronaWindowMovesWhenKeyboardAppears
 		end
 
+		-- Fetch the "initialSystemUiVisibility" flag used to set the systemUiVisibility before the splashScreen is shown.
+        if type(buildSettings.android.initialSystemUiVisibility) == "string" then
+        	initialSystemUiVisibility = buildSettings.android.initialSystemUiVisibility
+        end
+
 		-- Fetch a flag indicating if Corona's FileContentProvider should provide public read-only access to files.
 		if type(buildSettings.android.allowAppsReadOnlyAccessToFiles) == "boolean" then
 			allowAppsReadOnlyAccessToFiles = buildSettings.android.allowAppsReadOnlyAccessToFiles
@@ -700,6 +706,13 @@ if coronaWindowMovesWhenKeyboardAppears then
 	stringBuffer = '<meta-data android:name="coronaWindowMovesWhenKeyboardAppears" android:value="true" />'
 end
 manifestKeys.USER_CORONA_WINDOW_MOVES_WHEN_KEYBOARD_APPEARS = stringBuffer
+
+-- Create a meta-data tag for the "initialSystemUiVisibility" setting, if provided.
+stringBuffer = ""
+if initialSystemUiVisibility then
+	stringBuffer = '<meta-data android:name="initialSystemUiVisibility" android:value="true" />'
+end
+manifestKeys.USER_INITIAL_SYSTEM_UI_VISIBILITY = stringBuffer
 
 -- Create a "largeHeap" application tag attribute if set.
 stringBuffer = ""


### PR DESCRIPTION
This sets the systemUiVisibility even before the splashScreen comes up, avoiding the resize of the corona logo (which normally happens when settings immersiveSticky in main.lua)
For Android devices < 4.4 setting a initialSystemUiVisibility with `immersiveSticky` will automatically fall back to `lowProfile` mode.

Also added View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION flag to immersive & immersiveSticky modes.

This will prevent the resize event on Android which happens when starting the application. The application will immediately have the right dimension.
Without this, a Corona app on a 1920x1080 screen will start at 1776x1080 and resizes to 1920x1080 shortly after starting up (a "resize" event occurs)
With this, a Corona app will immediately start with 1920x1080 as display.pixelWidth & display.pixelHeight