### PR TITLE
Apply neverStripDebugInfo setting when building for Linux

### DIFF
--- a/platform/shared/Rtt_LinuxAppPackager.cpp
+++ b/platform/shared/Rtt_LinuxAppPackager.cpp
@@ -128,6 +128,14 @@ LinuxAppPackager::~LinuxAppPackager()
 
 int LinuxAppPackager::Build(AppPackagerParams* _params, WebServicesSession& session, const char* tmpDirBase)
 {
+	ReadBuildSettings(_params->GetSrcDir());
+	if (fNeverStripDebugInfo)
+	{
+		Rtt_LogException("Note: debug info is not being stripped from application (settings.build.neverStripDebugInfo = true)\n");
+
+		_params->SetStripDebug(false);
+	}
+
 	LinuxAppPackagerParams *params = (LinuxAppPackagerParams*) _params;
 	Rtt_ASSERT(params);
 

--- a/platform/shared/Rtt_WebAppPackager.cpp
+++ b/platform/shared/Rtt_WebAppPackager.cpp
@@ -123,6 +123,7 @@ namespace Rtt
 
 		// Package build settings parameters.
 		Rtt::AppPackagerParams params(p->GetAppName(), p->GetVersion(), p->GetIdentity(), NULL, srcDir, dstDir, NULL, p->GetTargetPlatform(), NULL,	0, 0, NULL, NULL, NULL, true);
+		params.SetStripDebug(p->IsStripDebug());
 
 		bool rc = CompileScriptsInDirectory(L, params, dstDir, srcDir);
 		if (rc)


### PR DESCRIPTION
This PR reads the `build.settings` file and applies the `neverStripDebugInfo` setting when building for Linux.