### PR TITLE
Allow Android to handle repeated volume button events

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/input/InputHandler.java
+++ b/platform/android/sdk/src/com/ansca/corona/input/InputHandler.java
@@ -73,7 +73,7 @@ public class InputHandler {
 		// Do not allow key repeat. The "down" event should only happen once per press.
 		KeyPhase phase = KeyPhase.from(event);
 		if ((phase == KeyPhase.DOWN) && (event.getRepeatCount() > 0)) {
-			return true;
+			return event.getKeyCode() != android.view.KeyEvent.KEYCODE_VOLUME_UP && event.getKeyCode() != android.view.KeyEvent.KEYCODE_VOLUME_DOWN;
 		}
 
 		// Ignore the key event if it came from the Corona runtime.


### PR DESCRIPTION
This will keep the functionality of not sending repeated "key" events to lua. But allows Android to decrease/increase the volume.