### PR TITLE
Allow to change the timeScale of an active SpriteObject

### DIFF
--- a/librtt/Display/Rtt_SpriteObject.cpp
+++ b/librtt/Display/Rtt_SpriteObject.cpp
@@ -1233,6 +1233,39 @@ SpriteObject::SetPlaying( bool newValue )
 	}
 }
 
+void
+SpriteObject::SetTimeScale( Real newValue ) {
+  // fStartTime = (U64)Rtt_RealDiv(Rtt_RealMul(fStartTime, fTimeScale), newValue);
+
+  SpriteObjectSequence *sequence = GetCurrentSequence();
+
+  if ( sequence )
+  {
+    if ( !IsPlaying() )
+    {
+      Real playTime = sequence->GetTimeForFrame(fCurrentFrame);
+      if ( ! Rtt_RealIsOne( newValue ) )
+      {
+        playTime = Rtt_RealDiv( playTime, newValue );
+      }
+      fPlayTime = Rtt_RealToInt( playTime );
+    }
+    else
+    {
+      U64 curTime = fPlayer.GetAnimationTime();
+      Real timeElapsed = curTime - fStartTime;
+      Real newTimeElapsed = Rtt_RealDiv(Rtt_RealMul(timeElapsed, fTimeScale), newValue);
+      if ( curTime >= Rtt_RealToInt(newTimeElapsed) ) {
+        fStartTime = curTime - Rtt_RealToInt(newTimeElapsed);
+      } else {
+        fStartTime = 0;
+      }
+    }
+  }
+
+  fTimeScale = newValue;
+}
+
 SpriteObjectSequence*
 SpriteObject::GetCurrentSequence() const
 {

--- a/librtt/Display/Rtt_SpriteObject.h
+++ b/librtt/Display/Rtt_SpriteObject.h
@@ -221,11 +221,11 @@ class SpriteObject : public RectObject
 
 	public:
 		Real GetTimeScale() const { return fTimeScale; }
-		void SetTimeScale( Real newValue ) { fTimeScale = newValue; }
+		void SetTimeScale( Real newValue );
 
 	protected:
-		bool IsProperty( PropertyMask mask ) const { return ( !! ( mask & fProperties ) ); } 
-		void SetProperty( PropertyMask mask, bool value ); 
+		bool IsProperty( PropertyMask mask ) const { return ( !! ( mask & fProperties ) ); }
+		void SetProperty( PropertyMask mask, bool value );
 
 	public:
 		bool IsPlaying() const;


### PR DESCRIPTION
If you set the time scale of an sprite object that is currently playing, it will keep the frame and allow smooth time scale transitions