### PR TITLE
Init SSL Library before calling ctx new.

### DIFF
--- a/platform/shared/CoronaLiveServer/CoronaLiveServerCore.cpp
+++ b/platform/shared/CoronaLiveServer/CoronaLiveServerCore.cpp
@@ -99,11 +99,11 @@ public:
 
 	SSLSetup(evhttp *httpd)
 	{
-		/*std::call_once(sOnceSSLInit, []{
+		std::call_once(sOnceSSLInit, []{
 			SSL_library_init();
 			SSL_load_error_strings();
 			OpenSSL_add_all_algorithms();
-		});*/
+		});
 
 		ctx = SSL_CTX_new(SSLv23_method());
 


### PR DESCRIPTION
SSL Library not initialized before calling SSL CTX new. Resulting in a null CTX.

At some point, the SSL use to be initialized someplace else (maybe with the license check). In any case, currently, the SSL is not initialized before the call to create a new CTX. This results in a null CTX that gets passed to another method and crashes the live server.