### PR TITLE
Adding support easy integration with solar2d marketplace

### DIFF
--- a/platform/resources/CoronaBuilderPluginCollector.lua
+++ b/platform/resources/CoronaBuilderPluginCollector.lua
@@ -171,8 +171,14 @@ function PluginCollectorSolar2DDirectory:collect(destination, plugin, pluginTabl
         return params.canSkip or "Solar2D Directory: skipped plugin " .. plugin .. " because platform " .. pluginPlatform .. " is not supported"
     end
     local repoName = pluginObject.p or (pluginTable.publisherId .. '-' .. plugin)
-    local downloadURL = "https://github.com/" .. repoOwner .. "/" .. repoName .. "/releases/download/" .. pluginObject.r .. "/" .. vFoundBuildName .. "-" .. pluginPlatform .. ".tgz"
+    local downloadURL
 
+    if pluginTable.marketplaceId then
+      downloadURL = "https://solar2dmarketplace.com/marketplacePlugins?pluginType=collector&ID=" .. pluginTable.marketplaceId .. "&plugin=" .. plugin .. "_" .. pluginTable.publisherId .. "&type=" .. pluginPlatform
+    else
+      downloadURL = "https://github.com/" .. repoOwner .. "/" .. repoName .. "/releases/download/" .. pluginObject.r .. "/" .. vFoundBuildName .. "-" .. pluginPlatform .. ".tgz"
+    end
+	
     local cacheDir = pathJoin(params.pluginStorage, "Caches", "Solar2Directory", repoOwner, pluginTable.publisherId, plugin, pluginPlatform )
     local cacheUrlFile = pathJoin(cacheDir, "info.txt")
     local cacheDestFile = pathJoin(cacheDir, "data.tgz")


### PR DESCRIPTION
I have done my testing on the rttplayer with Xcode
If you want to test it you can add this to your build.settings
plugins = {
		["plugin.firebaseAnalytics"] =
		{
			publisherId="tech.scotth",
			marketplaceId = "jdt0u5"
		},
	}

and this to your main.lua

local firebaseAnalytics = require ("plugin.firebaseAnalytics")
firebaseAnalytics.init()

This is not the best example because this plugin is available on plugins.solar2d but you get the idea.
If the user wants to use the solar2d marketplace they can choose to do so by just adding marketplaceId.

I hope to add better error support in the future. 

Thanks,
Scott