### PR TITLE
Reverting CFBundleVersion to old format

### DIFF
--- a/platform/resources/CoronaPListSupport.lua
+++ b/platform/resources/CoronaPListSupport.lua
@@ -215,7 +215,8 @@ function CoronaPListSupport.modifyPlist( options )
 			-- Apple treats this the build number so, if it hasn't been specified in the build.settings, we
 			-- set it to the current date and time which is unique for the app and human readable
 			bundleVersionSource = (infoPlist.CFBundleVersion == "@BUNDLE_VERSION@") and "set by Simulator" or "set by Info.plist"
-			infoPlist.CFBundleVersion = os.date("%Y.7%m.7%d%H%M")
+			local datedata = os.date( "!*t")
+			infoPlist.CFBundleVersion = datedata.year .. '.' .. datedata.month.."." .. datedata.day .. os.date("%H%M")
 		end
 
 		local version = options.bundleversion or "1.0.0"

--- a/platform/resources/CoronaPListSupport.lua
+++ b/platform/resources/CoronaPListSupport.lua
@@ -218,7 +218,7 @@ function CoronaPListSupport.modifyPlist( options )
 			infoPlist.CFBundleVersion = os.date("%Y.7%m.7%d%H%M")
 			local datedata = os.date( "!*t")
 			if datedata.year > 2020 then
-				infoPlist.CFBundleVersion = datedata.year .. '.' .. datedata.month.."." .. datedata.day .. os.date("%H%M")
+				infoPlist.CFBundleVersion = datedata.year .. '.' .. datedata.month.."." .. datedata.day .. os.date("!%H%M")
 			end
 		end
 

--- a/platform/resources/CoronaPListSupport.lua
+++ b/platform/resources/CoronaPListSupport.lua
@@ -215,11 +215,10 @@ function CoronaPListSupport.modifyPlist( options )
 			-- Apple treats this the build number so, if it hasn't been specified in the build.settings, we
 			-- set it to the current date and time which is unique for the app and human readable
 			bundleVersionSource = (infoPlist.CFBundleVersion == "@BUNDLE_VERSION@") and "set by Simulator" or "set by Info.plist"
+			infoPlist.CFBundleVersion = os.date("%Y.7%m.7%d%H%M")
 			local datedata = os.date( "!*t")
 			if datedata.year > 2020 then
 				infoPlist.CFBundleVersion = datedata.year .. '.' .. datedata.month.."." .. datedata.day .. os.date("%H%M")
-			else
-				infoPlist.CFBundleVersion = os.date("%Y.7%m.7%d%H%M")
 			end
 		end
 

--- a/platform/resources/CoronaPListSupport.lua
+++ b/platform/resources/CoronaPListSupport.lua
@@ -216,7 +216,11 @@ function CoronaPListSupport.modifyPlist( options )
 			-- set it to the current date and time which is unique for the app and human readable
 			bundleVersionSource = (infoPlist.CFBundleVersion == "@BUNDLE_VERSION@") and "set by Simulator" or "set by Info.plist"
 			local datedata = os.date( "!*t")
-			infoPlist.CFBundleVersion = datedata.year .. '.' .. datedata.month.."." .. datedata.day .. os.date("%H%M")
+			if datedata.year > 2020 then
+				infoPlist.CFBundleVersion = datedata.year .. '.' .. datedata.month.."." .. datedata.day .. os.date("%H%M")
+			else
+				infoPlist.CFBundleVersion = os.date("%Y.7%m.7%d%H%M")
+			end
 		end
 
 		local version = options.bundleversion or "1.0.0"


### PR DESCRIPTION
It seems some users were relying on the CFBundleVersion format. Reversing back to it for 2021