### PR TITLE
Maintenance: Updating copyright disclaimers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Solar2D.
+Copyright (c) 2020-2021 Solar2D.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external/remdebug-1.0/src/controller.lua
+++ b/external/remdebug-1.0/src/controller.lua
@@ -482,7 +482,7 @@ while true do
 	print("")
     print("Corona Debugger")
     print("version 1.1")
-	print("Copyright © 2008-2020 Corona Labs Inc. All rights reserved.")
+	print("Copyright © 2008-2021 Solar2D. All rights reserved.")
 	print("")
     print("Portions contain:")
 	print("    Lua, Copyright © 1994-2008 Lua.org, PUC-Rio.")

--- a/platform/apple/CoronaResources-Info.plist
+++ b/platform/apple/CoronaResources-Info.plist
@@ -39,6 +39,6 @@
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Corona Labs Inc. All rights reserved.</string>
+	<string>Copyright © 2020-2021 Solar2D. All rights reserved.</string>
 </dict>
 </plist>

--- a/platform/mac/CoronaConsole/CoronaConsole/Info.plist
+++ b/platform/mac/CoronaConsole/CoronaConsole/Info.plist
@@ -27,7 +27,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Corona Labs Inc. All rights reserved.</string>
+	<string>Copyright © 2020-2021 Solar2D. All rights reserved.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/platform/mac/Credits.rtfd/TXT.rtf
+++ b/platform/mac/Credits.rtfd/TXT.rtf
@@ -4,5 +4,5 @@
 \margl1440\margr1440\vieww12600\viewh10200\viewkind0
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\qc\partightenfactor0
 
-\f0\b\fs24 \cf0 Copyright \'a9 2020 Solar2D.\
+\f0\b\fs24 \cf0 Copyright \'a9 2020-2021 Solar2D.\
 All rights reserved.}

--- a/platform/mac/Info.plist
+++ b/platform/mac/Info.plist
@@ -76,7 +76,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Solar2D. All rights reserved.</string>
+	<string>Copyright © 2020-2021 Solar2D. All rights reserved.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/platform/windows/Corona.Simulator/Simulator.rc
+++ b/platform/windows/Corona.Simulator/Simulator.rc
@@ -597,7 +597,7 @@ BEGIN
             VALUE "FileDescription", "Solar2D Simulator"
             VALUE "FileVersion", "1.0.0.1"
             VALUE "InternalName", "Solar2D Simulator"
-            VALUE "LegalCopyright", "Copyright © 2020 Solar2D"
+            VALUE "LegalCopyright", "Copyright © 2020-2021 Solar2D"
             VALUE "OriginalFilename", "Solar2D Simulator"
             VALUE "ProductName", "Solar2D Simulator"
             VALUE "ProductVersion", "1.0.0.1"

--- a/sdk/dmg/Corona_License.rtf
+++ b/sdk/dmg/Corona_License.rtf
@@ -10,7 +10,7 @@
 \fs20 \
 \pard\tx0\tx959\tx1918\tx2877\tx3836\tx4795\tx5754\tx6713\tx7672\tx8631\pardeftab720\partightenfactor0
 \cf0  \
-Copyright (c) 2020, Solar2D.\
+Copyright (c) 2020-2021, Solar2D.\
  \
 All rights reserved.\
  \

--- a/sdk/dmg/Corona_LicenseBeta.rtf
+++ b/sdk/dmg/Corona_LicenseBeta.rtf
@@ -10,7 +10,7 @@
 \fs20 \
 \pard\tx0\tx959\tx1918\tx2877\tx3836\tx4795\tx5754\tx6713\tx7672\tx8631\pardeftab720\partightenfactor0
 \cf0  \
-Copyright (c) 2020, Solar2D.\
+Copyright (c) 2020-2021, Solar2D.\
  \
 All rights reserved.\
  \

--- a/tools/CoronaBuilder/CoronaBuilder-Info.plist
+++ b/tools/CoronaBuilder/CoronaBuilder-Info.plist
@@ -42,7 +42,7 @@
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2012-2020 Corona Labs Inc. All rights reserved.</string>
+	<string>Copyright © 2012-2021 Solar2D. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>


### PR DESCRIPTION
Just updating the copyright disclaimers.

Related maintenance PR for welcome screen at https://github.com/coronalabs/submodule-welcomescreen/pull/1