### PR TITLE
Update README mentions of Solar2DTux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solar2D Game Engine
 Download the latest build from the [Releases](https://github.com/coronalabs/corona/releases) page and join the community on [Discord](https://discord.gg/Abf5V9G) and the [forums](https://forums.solar2d.com/).
 
-For Linux, we suggest using the actively developed fork [Solar2DTux](https://github.com/DannyGlover/Solar2DTux).
+For Linux, you can run Solar2D using [Wine](https://www.winehq.org/). Alternatively, you may take a look at [Solar2DTux](https://github.com/DannyGlover/Solar2DTux), but note that Solar2DTux is not finished and it is currently not being developed.
 
 ## Rebranded Corona SDK
 > Simple to learn and use, completely free and open source 2D game engine.


### PR DESCRIPTION
Given the Solar2DTux is not being worked on and as it isn't finished, it's best to update the README file accordingly.