### PR TITLE
Allow local file access in Android webview

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/CoronaWebView.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaWebView.java
@@ -167,6 +167,7 @@ public class CoronaWebView extends WebView  implements NativePropertyResponder {
 		settings.setUseWideViewPort(true);
 		settings.setPluginState(android.webkit.WebSettings.PluginState.ON);
 		settings.setDomStorageEnabled(true);
+		settings.setAllowFileAccess(true);
 		if (android.os.Build.VERSION.SDK_INT >= 17) {
 			settings.setMediaPlaybackRequiresUserGesture(false);
 		}


### PR DESCRIPTION
Required since API level 30, as they changed the default from True to False.

https://developer.android.com/reference/android/webkit/WebSettings#setAllowFileAccess(boolean)

