### PR TITLE
Mask canvas fix, generalized

### DIFF
--- a/librtt/Display/Rtt_TextureResourceCanvas.cpp
+++ b/librtt/Display/Rtt_TextureResourceCanvas.cpp
@@ -57,12 +57,10 @@ TextureResourceCanvas* TextureResourceCanvas::Create(Rtt::TextureFactory &factor
 	Texture::Filter filter = RenderTypes::Convert( display.GetDefaults().GetMagTextureFilter() );
 	Texture::Wrap wrap = RenderTypes::Convert( display.GetDefaults().GetTextureWrapX() );
 
-#if !defined(Rtt_WIN_ENV)
 	if (Texture::kLuminance == format)
 	{
 		format = Texture::kRGBA;
 	}
-#endif
 
 	Texture *texture = Rtt_NEW( pAllocator,
 							   TextureVolatile( display.GetAllocator(), texWidth, texHeight, format, filter, wrap, wrap ) );


### PR DESCRIPTION
I first got this working on Windows, then learned it was failing at least on Android, and eventually fixed that.

I've recently had access to a Mac again, and saw that it was also broken elsewhere.

This generalizes the Android fix to all non-Windows platforms.