### PR TITLE
LightArrayPtr fix

### DIFF
--- a/librtt/Renderer/Rtt_Renderer.h
+++ b/librtt/Renderer/Rtt_Renderer.h
@@ -261,8 +261,8 @@ class Renderer
 		
 		MCPUResourceObserver *fCPUResourceObserver;
 		
-		Array<CPUResource*> fCreateQueue;
-		Array<CPUResource*> fUpdateQueue;
+		LightPtrArray<CPUResource> fCreateQueue;
+		LightPtrArray<CPUResource> fUpdateQueue;
 		Array<GPUResource*> fDestroyQueue;
 
 		GeometryPool* fGeometryPool;


### PR DESCRIPTION
This is a very tiny fix addressing the problem mentioned [here](https://github.com/coronalabs/corona/issues/397) and further elaborated on in the forum thread linked there. This seems to most affect frequently updated external textures but in theory could affect any new / updating `GPUResource` that was unlucky enough to happen on shutdown.