### PR TITLE
Simulator performance fix: treat repeated keys as handled

### DIFF
--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinInputDeviceManager.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinInputDeviceManager.cpp
@@ -963,6 +963,8 @@ void WinInputDeviceManager::OnReceivedMessage(
 			bool wasKeyPreviouslyDown = (arguments.GetLParam() & 0x40000000) ? true : false;
 			if ((isKeyDown && wasKeyPreviouslyDown) || (!isKeyDown && !wasKeyPreviouslyDown))
 			{
+				arguments.SetReturnResult(0);
+				arguments.SetHandled();
 				break;
 			}
 


### PR DESCRIPTION
In the simulator, _holding_ the up and down keys will slow things down dramatically in Windows. For instance, throw a few emitters out and do so and they'll draw to a crawl.

This seems to concern [this issue](https://github.com/coronalabs/corona/issues/358).

I don't know why only those keys seem to be affected. It did look like they might get hashed deep in their name lookup maps, but that's just a wild guess.

Anyhow, when repeating keys are detected, Solar is just backing out and trying some fallback logic. I don't know if this is necessarily expensive, but it's probably a pretty noisy event.

Since nothing else is going to handle it, it seems enough to mark this as handled and avoid those costs. (The speed increases substantially.) The Android skin / backspace logic seems to be fine, since that assumes a key up anyhow. (Incidentally, the repeat logic there is probably overkill, what with the key-is-up-and-was-up case.)