### PR TITLE
(Streaming fix) Use "main" device context exclusively on Windows

### DIFF
--- a/platform/windows/Corona.Native.Library.Win32/Interop/UI/RenderSurfaceControl.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Interop/UI/RenderSurfaceControl.cpp
@@ -26,7 +26,6 @@ RenderSurfaceControl::RenderSurfaceControl(HWND windowHandle)
 	fReceivedMessageEventHandler(this, &RenderSurfaceControl::OnReceivedMessage),
 	fRenderFrameEventHandlerPointer(nullptr),
 	fMainDeviceContextHandle(nullptr),
-	fPaintDeviceContextHandle(nullptr),
 	fRenderingContextHandle(nullptr)
 {
 	// Add event handlers.
@@ -70,12 +69,7 @@ void RenderSurfaceControl::SelectRenderingContext()
 	BOOL wasSelected = FALSE;
 	if (fRenderingContextHandle)
 	{
-		// Favor the Win32 BeginPaint() function's device context over our main device context, if available.
-		if (fPaintDeviceContextHandle)
-		{
-			wasSelected = ::wglMakeCurrent(fPaintDeviceContextHandle, fRenderingContextHandle);
-		}
-		else if (fMainDeviceContextHandle)
+		if (fMainDeviceContextHandle)
 		{
 			wasSelected = ::wglMakeCurrent(fMainDeviceContextHandle, fRenderingContextHandle);
 		}
@@ -115,11 +109,7 @@ void RenderSurfaceControl::SelectRenderingContext()
 
 void RenderSurfaceControl::SwapBuffers()
 {
-	if (fPaintDeviceContextHandle)
-	{
-		::SwapBuffers(fPaintDeviceContextHandle);
-	}
-	else if (fMainDeviceContextHandle)
+	if (fMainDeviceContextHandle)
 	{
 		::SwapBuffers(fMainDeviceContextHandle);
 	}
@@ -270,7 +260,6 @@ void RenderSurfaceControl::DestroyContext()
 		}
 		fMainDeviceContextHandle = nullptr;
 	}
-	fPaintDeviceContextHandle = nullptr;
 	fRendererVersion.SetString(nullptr);
 	fRendererVersion.SetMajorNumber(0);
 	fRendererVersion.SetMinorNumber(0);
@@ -436,26 +425,12 @@ void RenderSurfaceControl::OnReceivedMessage(UIComponent& sender, HandleMessageE
 		}
 		case WM_PAINT:
 		{
-			// Fetch this paint request's device context in case it is not targeting the display/monitor.
-			// For example, it could reference a printer device context.
-			PAINTSTRUCT paintStruct{};
-			HWND windowHandle = GetWindowHandle();
-			fPaintDeviceContextHandle = ::BeginPaint(windowHandle, &paintStruct);
-			bool hasPaintDeviceContext = (fPaintDeviceContextHandle != nullptr);
-
 			// Request the owner of this control to paint its content.
 			OnPaint();
 
-			// Release the BeginPaint() function's device context, if received.
-			if (hasPaintDeviceContext)
-			{
-				::EndPaint(windowHandle, &paintStruct);
-				fPaintDeviceContextHandle = nullptr;
-			}
-
 			// Flag that we've painted to the control's entire region.
 			// Note: Windows will keep sending this control paint messages until we've flagged it as validated.
-			ValidateRect(windowHandle, nullptr);
+			ValidateRect(GetWindowHandle(), nullptr);
 
 			// Flag that the paint message has been handled.
 			arguments.SetHandled();

--- a/platform/windows/Corona.Native.Library.Win32/Interop/UI/RenderSurfaceControl.h
+++ b/platform/windows/Corona.Native.Library.Win32/Interop/UI/RenderSurfaceControl.h
@@ -239,15 +239,6 @@ class RenderSurfaceControl : public Control
 		/// <summary>Handle to the control's main device context that OpenGL will render to.</summary>
 		HDC fMainDeviceContextHandle;
 
-		/// <summary>
-		///  <para>
-		///   Handle to the Win32 BeginPaint() device context, which is assigned when a paint message has been received.
-		///  </para>
-		///  <para>Set null if the control is not in the middle of a paint request.</para>
-		///  <para>This device context should be favored over "fMainDeviceContextHandle" for painting if available.</para>
-		/// </summary>
-		HDC fPaintDeviceContextHandle;
-
 		/// <summary>Handle to OpenGL's rendering context.</summary>
 		HGLRC fRenderingContextHandle;
 


### PR DESCRIPTION
Some folks in Discord brought up how attempts to stream (using Discord or OBS with the "newest technology", Game Capture sources, etc.) could just blow up on you. The RAM use would climb and climb and the game would then slow and usually crash, whether in simulator or a build.

A couple of us tried to hunt this down. The Vulkan backend seemed robust against it; in the GL backend, it could be "avoided" by commenting out the `SwapBuffers()` calls in the `RenderSurfaceControl`, although at the cost of a black screen. 😃

On a whim, I just commented out the `fPaintDeviceContextHandle` control paths in that class and tried it (from what I could see, the other device context was perfectly good), and everything was suddenly just fine. I'm assuming the streaming hooks get a hold of that `WM_PAINT` DC and completely violate its very temporary (`BeginPaint` -> `EndPaint`) lifetime, probably with some related allocation woes.

Given the perfectly serviceable `fMainDeviceContextHandle`, the transient one in `WM_PAINT` seems a bit pointless anyhow, an attempt to be **too** Windows-y. 😄 Maybe something like printers as alluded to in the comments will eventually need to be reconciled, but the streaming scenario is an immediate and pressing need, so I removed the  paint DC and related logic and hewed straight to the "main" one.