### PR TITLE
Windows frame timer fix

### DIFF
--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.cpp
@@ -15,7 +15,7 @@
 namespace Rtt
 {
 
-std::map<UINT_PTR, Rtt::WinTimer *> WinTimer::sTimerMap;
+std::unordered_map<UINT_PTR, Rtt::WinTimer *> WinTimer::sTimerMap;
 UINT_PTR WinTimer::sMostRecentTimerID;
 
 #pragma region Constructors/Destructors

--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.cpp
@@ -15,6 +15,9 @@
 namespace Rtt
 {
 
+std::map<UINT_PTR, Rtt::WinTimer *> WinTimer::sTimerMap;
+UINT_PTR WinTimer::sMostRecentTimerID;
+
 #pragma region Constructors/Destructors
 WinTimer::WinTimer(MCallback& callback, HWND windowHandle)
 :	PlatformTimer(callback)
@@ -46,7 +49,13 @@ void WinTimer::Start()
 	// We do this because Windows timers can invoke later than expected.
 	// To compensate, we'll schedule when to invoke the timer's callback using "fIntervalEndTimeInTicks".
 	fNextIntervalTimeInTicks = (S32)::GetTickCount() + (S32)fIntervalInMilliseconds;
-	fTimerPointer = ::SetTimer(fWindowHandle, (UINT_PTR)this, 10, WinTimer::OnTimerElapsed);
+	fTimerID = ++sMostRecentTimerID; // ID should be non-0, so pre-increment for first time
+	fTimerPointer = ::SetTimer(fWindowHandle, fTimerID, 10, WinTimer::OnTimerElapsed);
+
+	if (IsRunning())
+	{
+		sTimerMap[fTimerID] = this;
+	}
 }
 
 void WinTimer::Stop()
@@ -58,8 +67,12 @@ void WinTimer::Stop()
 	}
 
 	// Stop the timer.
-	::KillTimer(fWindowHandle, fTimerPointer);
+	::KillTimer(fWindowHandle, fTimerID);
+
+	sTimerMap.erase(fTimerID);
+
 	fTimerPointer = NULL;
+	fTimerID = 0;
 }
 
 void WinTimer::SetInterval(U32 milliseconds)
@@ -99,8 +112,11 @@ void WinTimer::Evaluate()
 #pragma region Private Methods/Functions
 VOID CALLBACK WinTimer::OnTimerElapsed(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
 {
-	WinTimer *timer = (WinTimer*)idEvent;
-	timer->Evaluate();
+	auto timer = sTimerMap.find(idEvent);
+	if (sTimerMap.end() != timer)
+	{
+		timer->second->Evaluate();
+	}
 }
 
 S32 WinTimer::CompareTicks(S32 x, S32 y)

--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.h
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.h
@@ -12,6 +12,7 @@
 #include "Core\Rtt_Build.h"
 #include "Rtt_PlatformTimer.h"
 #include <Windows.h>
+#include <map>
 
 
 namespace Rtt
@@ -79,8 +80,12 @@ class WinTimer : public PlatformTimer
 
 		HWND fWindowHandle;
 		UINT_PTR fTimerPointer;
+		UINT_PTR fTimerID;
 		U32 fIntervalInMilliseconds;
 		S32 fNextIntervalTimeInTicks;
+
+		static std::map<UINT_PTR, WinTimer*> sTimerMap; // timer callback might be called after Stop(), so use this as a guard
+		static UINT_PTR sMostRecentTimerID; // use an incrementing index as key, to be robust against the rare case that a new timer is reallocated into the same memory
 };
 
 }	// namespace Rtt

--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.h
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTimer.h
@@ -12,7 +12,7 @@
 #include "Core\Rtt_Build.h"
 #include "Rtt_PlatformTimer.h"
 #include <Windows.h>
-#include <map>
+#include <unordered_map>
 
 
 namespace Rtt
@@ -84,7 +84,7 @@ class WinTimer : public PlatformTimer
 		U32 fIntervalInMilliseconds;
 		S32 fNextIntervalTimeInTicks;
 
-		static std::map<UINT_PTR, WinTimer*> sTimerMap; // timer callback might be called after Stop(), so use this as a guard
+		static std::unordered_map<UINT_PTR, WinTimer*> sTimerMap; // timer callback might be called after Stop(), so use this as a guard
 		static UINT_PTR sMostRecentTimerID; // use an incrementing index as key, to be robust against the rare case that a new timer is reallocated into the same memory
 };
 


### PR DESCRIPTION
This is a fix for the issue brought up [here](https://github.com/coronalabs/corona/issues/402). Basically, the simulator will occasionally crash when you relaunch or close.

There's a possibility it's related to [this](https://github.com/coronalabs/corona/issues/186), but that will need some follow-up to confirm. I was testing using a project that did have audio, although I thought it had occurred in quiet ones too. In any case, it wouldn't be unreasonable that audio updates might exacerbate timer issues.

---------------------

**Details**:

Basically, it seems `KillTimer` does not actually evict relevant `WM_TIMER` messages from the queue, in which case they will still fire. There are vague hints of this in some online forum questions, but it's never spelled out. The problem in our case is that this might be after `WinTimer`'s destructor has gone off, so everything in our timer callback is garbage.

As mentioned in #402, it looks like the `network` library basically reused the `Rtt_WinTimer` code, apart from not assigning the timer to a window. Furthermore, it uses an ID &rarr; timer map, [using this in the callback](https://github.com/coronalabs/submodule-plugins-network/blob/696b05ae37c82bba6b6a6ee9a4639a77fb5250c8/win32/WinTimer.cpp#L26) to check if the timer still exists. I assume the same issue was being addressed.

I also mentioned in #402 that the wrong value was being passed to `KillTimer()`. This is per the [SetTimer docs](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-settimer): "If the function succeeds and the _hWnd_ parameter is not **NULL**, then the return value is a nonzero integer. An application can pass the value of the _nIDEvent_ parameter to the `KillTimer` function to destroy the timer." and also those for [KillTimer](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-killtimer): "The timer to be destroyed. If the window handle passed to `SetTimer` is valid, this parameter must be the same as the _nIDEvent_
 value passed to `SetTimer`."

I don't know what happens if this is wrong, but I figure it didn't amount to much because the timer was basically used for the entire run of a Solar program and went away when the window did, on close / relaunch. But in theory `WinTimer` is now more robust for wider use, with the revisions in this PR.

The changes are a lot like what `network` does. A map from ID &rarr; timer makes sure spurious callbacks do nothing. I used an incrementing ID (starting from 1) rather than what `SetTimer` returns ("If the function succeeds and the _hWnd_ parameter is not **NULL**, then the return value is a nonzero integer."), since I'm not sure if that's recycled; for the same reason I didn't use a `std::set`, for the rare-but-possible case that another timer were reallocated into that same memory. These concerns are a bit academic with the timer being a singleton used from launch to close / relaunch, but it's not at all impossible that timers could be put to wider use. 😄 