### PR TITLE
COM balancing and some fixed leaks

### DIFF
--- a/external/ALmixer/Isolated/DirectX.cpp
+++ b/external/ALmixer/Isolated/DirectX.cpp
@@ -79,7 +79,8 @@ DEFINE_ENUM_FLAG_OPERATORS(SoundDecoder_SampleFlags)
 static std::recursive_mutex sMutex;
 
 /// <summary>Stores a set of each thread ID this module has initialized Microsoft COM on.</summary>
-static std::unordered_set<std::thread::id> sComInitializedThreadIdSet;
+static std::unordered_set<std::thread::id> sComInitializedThreadIdSet; // This is a false positive (several, rather) for memory leaks:
+																		// the report occurs before static deinitialization / DLL detach
 
 /// <summary>
 ///  <para>Set true if the DirectX Media Foundation's MFStartup() function was called.</para>

--- a/external/openal-soft-1.12.854/Alc/alcConfig.c
+++ b/external/openal-soft-1.12.854/Alc/alcConfig.c
@@ -255,6 +255,8 @@ void ReadALConfig(void)
 
 void FreeALConfig(void)
 {
+    // N.B. these give us false positives for memory leaks: the report
+    // occurs before the DLLMain() that calls this function.
     size_t i;
 
     for(i = 0;i < cfgCount;i++)

--- a/librtt/Core/Rtt_Allocator.cpp
+++ b/librtt/Core/Rtt_Allocator.cpp
@@ -279,7 +279,7 @@ Rtt_AllocatorCreate( Rtt_ALLOCATOR_CREATE_ARG_DEFN )
 	#ifdef Rtt_USE_GLOBAL_VARIABLES
 		Rtt_Allocator* result = Rtt_Allocator::GetDefault();
 
-		if ( 0 == Rtt_Allocator::RefCount()++ )
+		if ( 0 == Rtt_Allocator::RefCount()++ ) // TODO: there is a four-byte memory leak due to unbalanced counts :)
 		{
 			result = new Rtt::Allocator( Rtt_ALLOCATOR_CREATE_ARG_LIST );
 			Rtt_Allocator::SetDefault( result );

--- a/librtt/Rtt_PlatformOpenALPlayer.cpp
+++ b/librtt/Rtt_PlatformOpenALPlayer.cpp
@@ -271,6 +271,8 @@ PlatformOpenALPlayer::QuitOpenALPlayer()
 		return;
 	}
 	
+	PlatformAudioSessionManager::Destroy();
+
 	// When ALmixer_Quits, Halt is called on all channels and callbacks are still invoked for final cleanups.
 	// However, this is a problem for us because we have hooks into the Lua scripts.
 	// It is possible that the lua state is already destroyed in which case a callback into Lua will cause problems.

--- a/platform/shared/Rtt_SimulatorAnalytics.cpp
+++ b/platform/shared/Rtt_SimulatorAnalytics.cpp
@@ -64,6 +64,8 @@ SimulatorAnalytics::~SimulatorAnalytics()
 	{
 		AnalyticsProviderFinish();
 	}
+
+	LuaContext::Delete( fVMContext );
 }
 
 bool

--- a/platform/windows/Corona.Simulator/SimulatorView.cpp
+++ b/platform/windows/Corona.Simulator/SimulatorView.cpp
@@ -157,8 +157,6 @@ CSimulatorView::CSimulatorView()
 {
 	CSimulatorApp *applicationPointer = (CSimulatorApp*)AfxGetApp();
 
-	CoInitialize(nullptr);
-
     mRotation = 0;  // current rotation
     mpSkinBitmap = nullptr;
 	mRuntimeEnvironmentPointer = nullptr;

--- a/platform/windows/Corona.Simulator/SimulatorView.cpp
+++ b/platform/windows/Corona.Simulator/SimulatorView.cpp
@@ -148,7 +148,8 @@ END_MESSAGE_MAP()
 #pragma region Constructor/Destructor
 /// Creates a new Corona Simulator CView.
 CSimulatorView::CSimulatorView()
-:	mSimulatorServices(*this),
+:	mScopedComInitializer(Interop::ScopedComInitializer::ApartmentType::kSingleThreaded),
+	mSimulatorServices(*this),
 	mMessageDlgPointer(nullptr),
 	mProgressDlgPointer(nullptr),
 	mDeviceConfig(*Rtt_AllocatorCreate()),

--- a/platform/windows/Corona.Simulator/SimulatorView.h
+++ b/platform/windows/Corona.Simulator/SimulatorView.h
@@ -11,6 +11,7 @@
 
 #include "Core\Rtt_Build.h"
 #include "Core\Rtt_Array.h"
+#include "Interop\ScopedComInitializer.h"
 #include "Interop\SimulatorRuntimeEnvironment.h"
 #include "Rtt_PlatformSimulator.h"
 #include "Rtt_TargetDevice.h"
@@ -177,6 +178,7 @@ class CSimulatorView : public CView
 		CCoronaControlContainer mCoronaContainerControl;
 		Interop::SimulatorRuntimeEnvironment* mRuntimeEnvironmentPointer;
 		Interop::SimulatorRuntimeEnvironment::LoadedEvent::MethodHandler<CSimulatorView> mRuntimeLoadedEventHandler;
+		Interop::ScopedComInitializer mScopedComInitializer;
 		Rtt::WinSimulatorServices mSimulatorServices;
 		CMessageDlg* mMessageDlgPointer;
 		CProgressWnd* mProgressDlgPointer;


### PR DESCRIPTION
I've been doing some hunting in Debug mode and often when closing a session would trigger an assert in **wincore.cpp, line 1055**. I dug into the MFC code and it led me to this post: <https://microsoft.public.vc.mfc.narkive.com/cGo3iW5V/afxmaphwnd-causing-an-assert-why>.

Following the comments, I did a little further investigation and found that the `CoInitialize(nullptr)` done by the Windows simulator view is never answered by a `CoUninitialize()`. This is supposedly a source of leaks and such.

I had also seen there was a class, `ScopedComInitializer`, intended to address this, so I made that a member of `CSimulatorView` and removed the original call. Per the [CoInitialize docs](https://docs.microsoft.com/en-us/windows/win32/api/objbase/nf-objbase-coinitialize), I used the single-threaded apartment type.

The assert seems to have gone away when quitting normally. I think exiting while stepping through code might still be able to do it&mdash;there is audio code without benefit of the scoped initializer&mdash;however, this is a marked improvement. 😄

---

Also in Debug mode, when quitting via the window's "X" (in Windows), you also get a memory leak report.

I finally decided to track these all down. (This was with some simple applications; maybe something more significant would flush out others.)

A few of these are valid. The audio session manager was never closed (just a pointer, 4 bytes), nor was the simulator analytics Lua context (small allocations, but quite a few of them).

Oddly enough, `Rtt_Allocator` has defeated my efforts to fix. 😃This is reference-counted, but the create / destroy calls are not yet balanced, so it leaks a pointer (4 bytes, again).

There are some further "leaks" in audio code: a `std::unordered_set` of thread IDs and some AL config info. These are false positives, though. The memory report is issued before the DLL cleanup that does in fact unload them.

I've made notes in the allocator and those two audio bits.

---

For reference, you should now see something like this in a report:

```
{279} normal block at 0x005E4748, 4 bytes long.
 Data: <    > 00 00 00 00 
{180} normal block at 0x005F8B58, 64 bytes long.
 Data: <8 _ 8 _ 8 _ 8 _ > 38 90 5F 00 38 90 5F 00 38 90 5F 00 38 90 5F 00 
{179} normal block at 0x005F91C0, 8 bytes long.
 Data: <( !z    > 28 EC 21 7A 00 00 00 00 
{178} normal block at 0x005F9620, 8 bytes long.
 Data: <  !z    > 1C EC 21 7A 00 00 00 00 
{177} normal block at 0x005F9038, 12 bytes long.
 Data: <8 _ 8 _     > 38 90 5F 00 38 90 5F 00 CD CD CD CD 
{96} normal block at 0x005E2B98, 8 bytes long.
 Data: <general > 67 65 6E 65 72 61 6C 00 
{95} normal block at 0x005E2BD0, 12 bytes long.
 Data: < +^         > 98 2B 5E 00 00 00 00 00 00 00 00 00 
```

On this run, allocation `279` was the `Rtt_Allocator`; `177` - `180` were the `std::unordered_set`; and `95` - `96` were the "first" AL `ConfigBlock` and its name (`"general"`).