### PR TITLE
Android: Fix method not found "isDeviceLocked"

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/SystemMonitor.java
+++ b/platform/android/sdk/src/com/ansca/corona/SystemMonitor.java
@@ -139,9 +139,14 @@ public class SystemMonitor {
 	public boolean isScreenLocked() {
 		android.app.KeyguardManager keyguardManager;
 		keyguardManager = (android.app.KeyguardManager)fContext.getSystemService(android.content.Context.KEYGUARD_SERVICE);
-		return keyguardManager.isDeviceLocked();
+		//Use new/updated method if supported
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP_MR1) {
+     return keyguardManager.isDeviceLocked();
+	 }else{
+		 return keyguardManager.inKeyguardRestrictedInputMode();
+	 }
+
 	}
-	
 	/**
 	 * Determines if the screen is currently unlocked and allows user interaction.
 	 * @return Returns true if screen is unlocked. Returns false if screen is locked or powered off.


### PR DESCRIPTION
Fix for older Android OS's not having "isDeviceLocked" (Android 5<)