### PR TITLE
Android: Fix for performance issue with WebViews

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/CoronaWebView.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaWebView.java
@@ -489,6 +489,9 @@ public class CoronaWebView extends WebView  implements NativePropertyResponder {
 				return;
 			}
 
+			//Fixes loading issue when alpha is used on long site 
+			view.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+
 			// Check if an error occurred for the given URL.
 			com.ansca.corona.events.DidFailLoadUrlTask errorEvent = fReceivedErrorEvents.get(url);
 			


### PR DESCRIPTION
Fix for Issue #287,
There is a slight performance issue with Android WebViews when "alpha" property is used before the page has loaded
See example below

`function showWebView(URL)
  local loadingMessage, webView = nil, nil
  local x, y = display.safeScreenOriginX + display.safeActualContentWidth/2, display.safeScreenOriginY + display.safeActualContentHeight/2

  local function webListener( event )
    if event.type == "loaded" then

      transition.to( webView, { time = 600, alpha = 1 } )
      transition.to( loadingMessage, { time = 400, alpha = 0 } )
    end
  end

  loadingMessage = display.newText({parent = webPopup, text = "LOADING PLEASE WAIT....", x = x, y = y, width = 400, font = native.systemFontBold, fontSize = 15, align = "left"})

  webView = native.newWebView( x, y, display.safeActualContentWidth, display.safeActualContentHeight )
  webView:request( URL )
  webView.alpha = 0
  webView:addEventListener( "urlRequest", webListener )
end

showWebView("https://catinfo.org")`
