### PR TITLE
Android/Simulator: option to package for Play Asset Delivery

### DIFF
--- a/platform/android/PAD.kts.template
+++ b/platform/android/PAD.kts.template
@@ -1,0 +1,50 @@
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+
+val padName = "pad-pack-name"
+val resource = "resource/path"
+val padType = "on-demand"
+// values above are templated
+
+val coronaTmpDir: String? by project
+val coronaSrcDir = project.findProperty("coronaSrcDir") as? String
+    ?: if (file("$rootDir/../test/assets2").exists()) {
+        "$rootDir/../test/assets2"
+    } else {
+        "$rootDir/../Corona"
+    }
+
+plugins {
+    id("com.android.asset-pack")
+}
+
+assetPack {
+    packName.set(padName)
+    dynamicDelivery {
+        deliveryType.set(padType)
+    }
+}
+
+
+val copyS2DAssets = tasks.register<Copy>("copyResourcesForTag") {
+    description = "Copy $padName assets"
+    from(coronaSrcDir) {
+        include("$resource/**/*")
+        include(resource)
+    }
+    file("$coronaTmpDir/excludesfile.properties").takeIf { it.exists() }?.readLines()?.forEach {
+        exclude(it)
+    }
+    exclude("**/Icon\r")
+    exclude("AndroidResources/**")
+    exclude("**/*.lua", "build.settings")
+
+    into("src/main/assets")
+
+    doFirst {
+        delete("src/main/assets")
+    }
+}
+
+project.afterEvaluate {
+    tasks.named("generateAssetPackManifest").dependsOn(copyS2DAssets)
+}

--- a/platform/android/settings.gradle.kts
+++ b/platform/android/settings.gradle.kts
@@ -1,3 +1,17 @@
+import com.beust.klaxon.lookup
+import com.beust.klaxon.JsonObject
+import com.beust.klaxon.JsonArray
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath("com.beust:klaxon:5.0.1")
+    }
+}
+
 rootProject.name = "Corona Android"
 include(":App")
 project(":App").projectDir = file("app")
@@ -10,4 +24,36 @@ if (file("sdk").exists()) {
 val coronaExpansionFileName: String? by settings
 if(!coronaExpansionFileName.isNullOrBlank()) {
     include(":preloadedAssets")
+}
+
+val coronaTmpDir: String? by settings
+val parsedBuildProperties: JsonObject? = run {
+    coronaTmpDir?.let { srcDir ->
+        file("$srcDir/build.properties").takeIf { it.exists() }?.let { f ->
+            return@run com.beust.klaxon.Parser.default().parse(f.absolutePath) as JsonObject
+        }
+    }
+}
+parsedBuildProperties?.lookup<JsonArray<JsonObject>>("buildSettings.android.onDemandResources")?.firstOrNull()?.forEach {
+    val tag : String = it["tag"]?.toString() ?: throw InvalidPluginException("Missing 'tag' for onDemand/PlayDelivery asset")
+    val resource : String = it["resource"]?.toString() ?: throw InvalidPluginException("Missing 'resource' for onDemand/PlayDelivery asset tagged '$tag'")
+    val type : String = when( it["type"] ) {
+        "prefetch", "fast-follow" -> "fast-follow"
+        "install", "install-time" -> "install-time"
+        null, "on-demand" -> "on-demand"
+        else -> throw InvalidPluginException("Invalid 'type' for onDemand/PlayDelivery resource tagged '$tag'. Must be 'prefetch' ('fast-follow'), 'install' ('install-time') or nil ('on-demand')")
+    }
+    val padName = "pda-$tag"
+    mkdir(padName)
+    copy {
+        from(".") {
+            include("PAD.kts.template")
+            rename { "build.gradle.kts" }
+        }
+        into(padName)
+        filter { line ->
+            line.replace("pad-pack-name", tag).replace("resource/path", resource).replace("on-demand", type)
+        }
+    }
+    include(":$padName")
 }

--- a/platform/mac/AndroidAppBuildController.mm
+++ b/platform/mac/AndroidAppBuildController.mm
@@ -947,7 +947,7 @@ static NSString *kChooseFromFollowing = @"Choose from the following…";
 
 - (NSString*)appExtension
 {
-	return @"apk";
+	return @"aab";
 }
 
 -(void)sheetDidEnd:(NSWindow*)sheet returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo

--- a/platform/resources/valid_build_settings.lua
+++ b/platform/resources/valid_build_settings.lua
@@ -30,6 +30,7 @@ settings =
 {
 	android =
 	{
+		onDemandResources = { },
 		usesFeatures = { },
 		intentFilters = { },
 		usesPermissions = { "" },
@@ -112,6 +113,7 @@ settings =
 
 	iphone =
 	{
+		onDemandResources = { },
 		iCloud = true,
 		skipPNGCrush = true,
 		xcassets = "",
@@ -214,6 +216,7 @@ settings =
 
 	osx =
 	{
+		onDemandResources = { },
 		iCloud = {},
 		bundleResourcesDirectory = "",
 		entitlements = { },
@@ -286,9 +289,7 @@ settings =
 	{
 		iCloud = true,
 		xcassets = "",
-		onDemandResources = {
-			{ },
-		},
+		onDemandResources = { },
 		-- tvOS app icons require multiple layers, and must provide both a small and a large size.
 		icon =
 		{


### PR DESCRIPTION
Follows same syntax as [onDemandResources](https://docs.coronalabs.com/plugin/onDemandResources/index.html#project-settings)

Sample code:
```lua
settings =
{
	android = {
		onDemandResources = {
			{ tag = "odr1", resource="sampleUI" },
			{ tag = "odr2", resource="rakkann.png", type="install" },
		},
	},
}
```