### PR TITLE
macOS/Windows: adding new windowState event to indicate that window was activated/deactivated

### DIFF
--- a/librtt/Rtt_Event.cpp
+++ b/librtt/Rtt_Event.cpp
@@ -384,6 +384,30 @@ ResizeEvent::Push( lua_State *L ) const
 
 // ----------------------------------------------------------------------------
 
+/// Creates a new event indicating that the main was activated or deactivated
+WindowStateEvent::WindowStateEvent(bool foreground) : fForeground(foreground)
+{
+}
+
+const char*
+WindowStateEvent::Name() const
+{
+	static const char kName[] = "windowState";
+	return kName;
+}
+
+int
+WindowStateEvent::Push( lua_State *L ) const
+{
+	Super::Push( L );
+	lua_pushstring( L, fForeground?"foreground":"background");
+	lua_setfield( L, -2, kPhaseKey );
+	return 1;
+}
+
+
+// ----------------------------------------------------------------------------
+
 /// Creates a new event data object that stores a single accelerometer measurement.
 /// @param gravity Pointer to an array of 3 elements storing smoothed acceleration data.
 /// @param instant Pointer to an array of 3 elements storing acceleration deltas based on smoother/gravity data.

--- a/librtt/Rtt_Event.h
+++ b/librtt/Rtt_Event.h
@@ -281,6 +281,24 @@ class ResizeEvent : public VirtualEvent
 // ----------------------------------------------------------------------------
 
 // Immediately broadcast to "Runtime"
+class WindowStateEvent : public VirtualEvent
+{
+	public:
+		typedef VirtualEvent Super;
+
+	public:
+		WindowStateEvent(bool foreground);
+
+	public:
+		virtual const char* Name() const;
+		virtual int Push( lua_State *L ) const;
+	private:
+		bool fForeground;
+};
+
+// ----------------------------------------------------------------------------
+
+// Immediately broadcast to "Runtime"
 class AccelerometerEvent : public VirtualEvent
 {
 	public:

--- a/platform/mac/AppDelegate.mm
+++ b/platform/mac/AppDelegate.mm
@@ -1621,6 +1621,20 @@ Rtt_EXPORT const luaL_Reg* Rtt_GetCustomModulesList()
 
 - (void)applicationWillResignActive:(NSNotification *)aNotification
 {
+	if(self.simulator && self.simulator->GetPlayer() ) {
+		Runtime& runtime = self.simulator->GetPlayer()->GetRuntime();
+		WindowStateEvent e( false );
+		runtime.DispatchEvent( e );
+	}
+}
+
+- (void) applicationDidBecomeActive:(NSNotification *)notification
+{
+	if(self.simulator && self.simulator->GetPlayer() ) {
+		Runtime& runtime = self.simulator->GetPlayer()->GetRuntime();
+		WindowStateEvent e( true );
+		runtime.DispatchEvent( e );
+	}
 }
 
 -(BOOL)isRelaunchable

--- a/platform/mac/CoronaShell/CoronaShell/AppDelegate.m
+++ b/platform/mac/CoronaShell/CoronaShell/AppDelegate.m
@@ -529,6 +529,23 @@
 	NSLog(@"notifyRuntimeError: %@", mesg);
 }
 
+- (void)applicationWillResignActive:(NSNotification *)notification
+{
+	NSDictionary *event = @{ @"name" : @"windowState",
+							 @"phase" : @"background" };
+
+    [_coronaView sendEvent:event];
+}
+
+- (void) applicationDidBecomeActive:(NSNotification *)notification
+{
+	NSDictionary *event = @{ @"name" : @"windowState",
+							 @"phase" : @"foreground" };
+
+    [_coronaView sendEvent:event];
+}
+
+
 - (void) performPause:(id) sender
 {
 	// NSDEBUG(@"performPause: %@", sender);

--- a/platform/windows/Corona.Native.Library.Win32/Interop/RuntimeEnvironment.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Interop/RuntimeEnvironment.cpp
@@ -1697,6 +1697,15 @@ void RuntimeEnvironment::OnMainWindowReceivedMessage(UI::UIComponent &sender, UI
 {
 	switch (arguments.GetMessageId())
 	{
+		case WM_ACTIVATE:
+		{
+			if (fRuntimePointer)
+			{
+				Rtt::WindowStateEvent event(arguments.GetWParam() > 0);
+				fRuntimePointer->DispatchEvent(event);
+			}
+			break;
+		}
 		case WM_SIZING:
 		{
 			// Make sure the window is not made smaller than the configured min width/height, if provided.


### PR DESCRIPTION
Event name: `windowState`
Event data: `phase` is either `"foreground"` or `"background"`. 

```lua
Runtime:addEventListener( "windowState", function(e)
	if e.phase == "foreground" then
		-- do something when activating
        elseif  e.phase == "background" then
                --- deactivate stuff not needed in background
	end
end )

```