### PR TITLE
Some small issues in canvas texture setup

### DIFF
--- a/librtt/Display/Rtt_LuaLibGraphics.cpp
+++ b/librtt/Display/Rtt_LuaLibGraphics.cpp
@@ -1193,14 +1193,34 @@ SharedPtr<TextureResource> CreateResourceCanvasFromTable(Rtt::TextureFactory &fa
     }
     lua_pop( L, 1 );
     
+    if ( width <= 0 && pixelWidth > 0 )
+    {
+        width = pixelWidth;
+    }
+    if ( height <= 0 && pixelHeight > 0 )
+    {
+        height = pixelHeight;
+    }
+
     if( width > 0 && height > 0 )
     {
         
         if (pixelWidth <= 0 || pixelHeight <= 0)
         {
+            S32 unused = 0, oldPixelWidth = pixelWidth, oldPixelHeight = pixelHeight;
             pixelWidth = Rtt_RealToInt( width );
             pixelHeight = Rtt_RealToInt( height );
-            display.ContentToScreen( pixelWidth, pixelHeight );
+            display.ContentToScreen( unused, unused, pixelWidth, pixelHeight );
+            
+            // if one of the values was specified, use that instead:
+            if (oldPixelWidth > 0)
+            {
+                pixelWidth = oldPixelWidth;
+            }
+            else if (oldPixelHeight > 0)
+            {
+                pixelHeight = oldPixelHeight;
+            }
         }
         
         int texSize = display.GetMaxTextureSize();

--- a/librtt/Display/Rtt_SnapshotObject.cpp
+++ b/librtt/Display/Rtt_SnapshotObject.cpp
@@ -170,9 +170,10 @@ SnapshotObject::Initialize( lua_State *L, Display& display, Real contentW, Real 
 	Rtt_ASSERT( GetStage() );
 	
 	// Calculate pixel dimensions for texture
+	S32 unused = 0;
 	S32 pixelW = Rtt_RealToInt( contentW );
 	S32 pixelH = Rtt_RealToInt( contentH );
-	display.ContentToScreen( pixelW, pixelH );
+	display.ContentToScreen( unused, unused, pixelW, pixelH );
 
 	TextureFactory& factory = display.GetTextureFactory();
 


### PR DESCRIPTION
This fixes a bug described [here](https://github.com/coronalabs/corona/issues/418):

The two-argument `ContentToScreen()` is used for convenience when calculating the pixel dimensions of the canvas, since the coordinates would go unused. Unfortunately, that's _meant_ for coordinates, and so it drags any non-0 screen origins into the calculation.

(Snapshots also do this.)

A more minor issue: if `pixelWidth` or `pixelHeight` was provided as a canvas option, but not both, they were ignored.

This also adds a (backward-compatible) shorthand for setting `width` and `pixelWidth` to the same value (ditto height): if `pixelWidth` is provided but not `width`, it will be used for both.