### PR TITLE
Fix for corner case where vertex format extension block was present but not the corresponding list

### DIFF
--- a/librtt/Display/Rtt_DisplayPath.cpp
+++ b/librtt/Display/Rtt_DisplayPath.cpp
@@ -210,7 +210,7 @@ DisplayPath::ExtensionAdapter::ValueForKey(
             {
                 const Geometry::ExtensionBlock* block = geometry->GetExtensionBlock();
                 
-                if (block && (block->fInstanceData || geometry->GetExtensionList()->instancedByID))
+                if ( Geometry::UsesInstancing( block, geometry->GetExtensionList() ) )
                 {
                     lua_pushnumber( L, block->fCount );
                 }

--- a/librtt/Renderer/Rtt_Geometry_Renderer.cpp
+++ b/librtt/Renderer/Rtt_Geometry_Renderer.cpp
@@ -1341,6 +1341,14 @@ Geometry::EnsureExtension()
     
     return fExtension;
 }
+ 
+bool
+Geometry::UsesInstancing( const ExtensionBlock* block, const FormatExtensionList* list )
+{
+    bool instancedByID = list && list->instancedByID;
+
+    return block && (block->fInstanceData || instancedByID);
+}
 
 // ----------------------------------------------------------------------------
 

--- a/librtt/Renderer/Rtt_Geometry_Renderer.h
+++ b/librtt/Renderer/Rtt_Geometry_Renderer.h
@@ -179,6 +179,8 @@ class Geometry : public CPUResource
  
         ExtensionBlock * GetExtensionBlock() const { return fExtension; }
         ExtensionBlock * EnsureExtension();
+     
+        static bool UsesInstancing( const ExtensionBlock* block, const FormatExtensionList* list );
     
         // More space may be allocated than is initially needed. By default,
         // the use count is zero and must be set for Geometry to be useful.

--- a/librtt/Renderer/Rtt_Renderer.cpp
+++ b/librtt/Renderer/Rtt_Renderer.cpp
@@ -592,7 +592,7 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
     }
     
     const Geometry::ExtensionBlock* block = geometry->GetExtensionBlock();
-    bool isInstanced = block && (block->fInstanceData || extensionList->instancedByID);
+    bool isInstanced = Geometry::UsesInstancing( block, extensionList );
 
     // Geometry that is stored on the GPU does not need to be copied
     // over each frame. As a consequence, they can not be batched.


### PR DESCRIPTION
This fixes a minor issue that could crop up if you tried to read an object's format extension data  before assigning any. This was flushed it by reading `_properties` on an object.

Both the block and list are now checked against `NULL` where needed, using a new helper function.