### PR TITLE
Fix for transparent skinnable windows

### DIFF
--- a/platform/mac/SkinView.mm
+++ b/platform/mac/SkinView.mm
@@ -249,7 +249,7 @@ static size_t Internal_GetMaxTextureSize()
 
 		if (isTransparent)
 		{
-			[[self layer] setOpacity:0.0];
+			[[self layer] setOpacity:0.125];
 		}
 	
 		[[self layer] addSublayer:[self layerView]];

--- a/platform/mac/SkinnableWindow.h
+++ b/platform/mac/SkinnableWindow.h
@@ -24,6 +24,7 @@
 	NSPoint fMouseDownLocation;
 
 	SkinView* fSkinView;
+	BOOL fIsTransparent;
 }
 
 - (id)initWithScreenView:(GLView*)screenView

--- a/platform/mac/SkinnableWindow.mm
+++ b/platform/mac/SkinnableWindow.mm
@@ -81,6 +81,8 @@
 		// is capable of so that we take advantage of Retina screens
 		[fScreenView setWantsBestResolutionOpenGLSurface:YES];
 		[fScreenView setZoomLevel:1.0];
+		
+		fIsTransparent = isTransparent;
 
 		if (isTransparent)
 		{
@@ -147,7 +149,7 @@
 		Rtt_ASSERT( fScreenView );
 		if ( ! fSkinView )
 		{
-			SkinView* skinView = [[SkinView alloc] initWithFrame:NSZeroRect];
+			SkinView* skinView = [[SkinView alloc] initWithFrame:NSZeroRect isTransparent:fIsTransparent];
 			fSkinView = skinView;
 			[skinView autorelease];
 		}


### PR DESCRIPTION
The support for transparent windows was botched for simulator skins. (These devices are not the target platform, but it seems helpful to provide it.) The `setSkinImage` function wanted an `isTransparent` argument and thus, due to lack of that, was just getting ignored. So skins weren't showing up.

The skin view's opacity was also being set to 0.0 when requesting transparency, so would also be hidden for that reason. Now it's set to a small value (0.125, somewhat arbitrary) so you can still see the skin, just faded.

-------

There are still some compromises, probably unavoidable, versus what you would see in a build:

* Because there is a faded skin behind them, any transparent background parts will be slightly less so
* Opaque parts of the content area stand out where screen dressing would normally obscure them (looks a bit odd)