### PR TITLE
Fix for indexed meshes on Android, related to custom vertex formats

### DIFF
--- a/librtt/Renderer/Rtt_CommandBuffer.h
+++ b/librtt/Renderer/Rtt_CommandBuffer.h
@@ -86,7 +86,7 @@ class CommandBuffer
         // by the underlying rendering API.
         virtual void BindFrameBufferObject( FrameBufferObject* fbo, bool asDrawBuffer = false ) = 0;
 		virtual void CaptureRect( FrameBufferObject* fbo, Texture& texture, const Rect& rect, const Rect& rawRect ) = 0;
-		virtual void BindGeometry( Geometry* geometry ) = 0;
+		virtual void BindGeometry( Geometry* geometry, U32 vertexExtra = 0 ) = 0;
         virtual void BindTexture( Texture* texture, U32 unit ) = 0;
         virtual void BindUniform( Uniform* uniform, U32 unit ) = 0;
         virtual void BindProgram( Program* program, Program::Version version ) = 0;

--- a/librtt/Renderer/Rtt_GLCommandBuffer.cpp
+++ b/librtt/Renderer/Rtt_GLCommandBuffer.cpp
@@ -500,10 +500,11 @@ GLCommandBuffer::CaptureRect( FrameBufferObject* fbo, Texture& texture, const Re
 }
 
 void
-GLCommandBuffer::BindGeometry( Geometry* geometry )
+GLCommandBuffer::BindGeometry( Geometry* geometry, U32 vertexExtra )
 {
     WRITE_COMMAND( kCommandBindGeometry );
     Write<GPUResource*>( geometry->GetGPUResource() );
+    Write<U32>( vertexExtra );
 }
 
 void
@@ -1023,7 +1024,14 @@ GLCommandBuffer::Execute( bool measureGPU )
             case kCommandBindGeometry:
             {
                 geometry = Read<GLGeometry*>();
+                U32 vertexExtra = Read<U32>();
                 geometry->Bind();
+                if ( !formatDirty && geometry->StoredOnGPU() && !geometry->HasArrayObject() )
+                {
+                    const U32 size = sizeof(Geometry::Vertex) * (1 + vertexExtra);
+                    
+                    geometry->BindStockAttributes( size );
+                }
                 DEBUG_PRINT( "Bind Geometry %p (stored on GPU = %s)", geometry, geometry->StoredOnGPU() ? "true" : "false" );
                 CHECK_ERROR_AND_BREAK;
             }

--- a/librtt/Renderer/Rtt_GLCommandBuffer.h
+++ b/librtt/Renderer/Rtt_GLCommandBuffer.h
@@ -47,7 +47,7 @@ class GLCommandBuffer : public CommandBuffer
         // specified state changes.
         virtual void BindFrameBufferObject( FrameBufferObject* fbo, bool asDrawBuffer );
 		virtual void CaptureRect( FrameBufferObject* fbo, Texture& texture, const Rect& rect, const Rect& rawRect );
-		virtual void BindGeometry( Geometry* geometry );
+		virtual void BindGeometry( Geometry* geometry, U32 vertexExtra );
         virtual void BindTexture( Texture* texture, U32 unit );
         virtual void BindUniform( Uniform* uniform, U32 unit );
         virtual void BindProgram( Program* program, Program::Version version );

--- a/librtt/Renderer/Rtt_GLGeometry.h
+++ b/librtt/Renderer/Rtt_GLGeometry.h
@@ -41,6 +41,7 @@ class GLGeometry : public GPUResource
         static void VertexAttribDivisor( GLuint index, GLuint divisor);
     
         bool StoredOnGPU() const { return !!fVBO; }
+        bool HasArrayObject() const { return !!fVAO; }
         GLbyte* GetBaseOffset() const { return (GLbyte*)fPositionStart + fVertexOffset * sizeof(Geometry::Vertex); }
     
         void SpliceVertexRateData( const Geometry::Vertex* vertexData, Geometry::Vertex* extendedVertexData, const FormatExtensionList * list, size_t & size );

--- a/librtt/Renderer/Rtt_Renderer.cpp
+++ b/librtt/Renderer/Rtt_Renderer.cpp
@@ -571,6 +571,7 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
     }
 
     const FormatExtensionList* extensionList = geometry->GetExtensionList();
+    const U32 vertexExtra = extensionList ? extensionList->ExtraVertexCount() : 0;
     bool formatsDirty = !FormatExtensionList::Match( previousGeometryList, extensionList );
 
     if (!formatsDirty && data->fProgram != fPrevious.fProgram)
@@ -608,7 +609,7 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
                 QueueCreate( geometry );
             }
         
-            fBackCommandBuffer->BindGeometry( geometry );
+            fBackCommandBuffer->BindGeometry( geometry, vertexExtra );
             fPrevious.fGeometry = geometry;
 
             if (isInstanced)
@@ -681,7 +682,6 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
         
         // Depending on batching, wireframe, etc, the amount of space
         // needed may be more than what is used by the Geometry itself.
-        const U32 vertexExtra = extensionList ? extensionList->ExtraVertexCount() : 0;
         const U32 verticesComputed = ComputeRequiredVertices( geometry, fWireframeEnabled );
         const U32 verticesRequired = verticesComputed * (1 + vertexExtra);
 //        bool enoughSpace = fCurrentGeometry;

--- a/librtt/Renderer/Rtt_VulkanCommandBuffer.cpp
+++ b/librtt/Renderer/Rtt_VulkanCommandBuffer.cpp
@@ -352,7 +352,7 @@ VulkanCommandBuffer::BindFrameBufferObject( FrameBufferObject* fbo, bool ) // TO
 }
 
 void 
-VulkanCommandBuffer::BindGeometry( Geometry* geometry )
+VulkanCommandBuffer::BindGeometry( Geometry* geometry, U32 )
 {
 	WRITE_COMMAND( kCommandBindGeometry );
 	Write<GPUResource*>( geometry->GetGPUResource() );

--- a/librtt/Renderer/Rtt_VulkanCommandBuffer.h
+++ b/librtt/Renderer/Rtt_VulkanCommandBuffer.h
@@ -78,7 +78,7 @@ class VulkanCommandBuffer : public CommandBuffer
 		// specified state changes.
 		virtual void BindFrameBufferObject( FrameBufferObject* fbo, bool asDrawBuffer );
 		virtual void CaptureRect( FrameBufferObject* fbo, Texture& texture, const Rect& rect, const Rect& rawRect ) { Rtt_ASSERT_NOT_IMPLEMENTED(); }
-		virtual void BindGeometry( Geometry* geometry );
+		virtual void BindGeometry( Geometry* geometry, U32 );
 		virtual void BindTexture( Texture* texture, U32 unit );
 		virtual void BindUniform( Uniform* uniform, U32 unit );
 		virtual void BindProgram( Program* program, Program::Version version );


### PR DESCRIPTION
Custom vertex formats introduced a corner case where these broke due to vertex attributes not being set. This control path wasn't followed if there was a VAO, thus Android being where it was discovered.

The relevant information is now passed along with the binding, and done afterward if a format change isn't also due.