### PR TITLE
NX: fix obsolete preprocessor condition

### DIFF
--- a/platform/linux/src/Rtt_Assert.cpp
+++ b/platform/linux/src/Rtt_Assert.cpp
@@ -200,7 +200,7 @@ Rtt_VLogException(const char* format, va_list ap)
 			}
 
 			// Output the string to stdout and the Visual Studio debugger.
-#if defined(Rtt_NINTENDO_ENV)
+#if defined(Rtt_NXS_ENV)
 			fputs(stringPointer, stdout);
 #elif defined(Rtt_WIN_PHONE_ENV)
 			if (fLogHandler)


### PR DESCRIPTION
@bakeinflash I see renames nearby fb4467aae2c955356e516b08fd04e4e01dcf326d rename `Rtt_NINTENDO_ENV` to `Rtt_NXS_ENV`, and 0199bc0b75fd160a3d187e8650219cd8835ffd86 introduced an old name.

Most preprocessors was defined in `librtt/Core/Rtt_Config.h` below `Rtt_NXS_ENV` rather than `Rtt_NINTENDO_ENV` so we should use NXS AFAIK.