### PR TITLE
Some vertex format logic fixes and streamlining

### DIFF
--- a/librtt/Renderer/Rtt_CommandBuffer.h
+++ b/librtt/Renderer/Rtt_CommandBuffer.h
@@ -86,14 +86,12 @@ class CommandBuffer
         // by the underlying rendering API.
         virtual void BindFrameBufferObject( FrameBufferObject* fbo, bool asDrawBuffer = false ) = 0;
 		virtual void CaptureRect( FrameBufferObject* fbo, Texture& texture, const Rect& rect, const Rect& rawRect ) = 0;
-		virtual void BindGeometry( Geometry* geometry, U32 vertexExtra = 0 ) = 0;
+		virtual void BindGeometry( Geometry* geometry ) = 0;
         virtual void BindTexture( Texture* texture, U32 unit ) = 0;
         virtual void BindUniform( Uniform* uniform, U32 unit ) = 0;
         virtual void BindProgram( Program* program, Program::Version version ) = 0;
         virtual void BindInstancing( U32 count, Geometry::Vertex* instanceData ) = 0;
-        virtual void DirtyVertexFormat() = 0;
-        virtual void BindVertexFormat( FormatExtensionList* extensionList, U16 fullCount, U16 vertexSize ) = 0;
-        virtual void BindVertexOffset( U32 offset, U32 extraVertexCount ) = 0;
+        virtual void BindVertexFormat( FormatExtensionList* extensionList, U16 fullCount, U16 vertexSize, U32 offset ) = 0;
         virtual void SetBlendEnabled( bool enabled ) = 0;
         virtual void SetBlendFunction( const BlendMode& mode ) = 0;
         virtual void SetBlendEquation( RenderTypes::BlendEquation equation ) = 0;

--- a/librtt/Renderer/Rtt_GLCommandBuffer.h
+++ b/librtt/Renderer/Rtt_GLCommandBuffer.h
@@ -47,14 +47,12 @@ class GLCommandBuffer : public CommandBuffer
         // specified state changes.
         virtual void BindFrameBufferObject( FrameBufferObject* fbo, bool asDrawBuffer );
 		virtual void CaptureRect( FrameBufferObject* fbo, Texture& texture, const Rect& rect, const Rect& rawRect );
-		virtual void BindGeometry( Geometry* geometry, U32 vertexExtra );
+		virtual void BindGeometry( Geometry* geometry );
         virtual void BindTexture( Texture* texture, U32 unit );
         virtual void BindUniform( Uniform* uniform, U32 unit );
         virtual void BindProgram( Program* program, Program::Version version );
         virtual void BindInstancing( U32 count, Geometry::Vertex* instanceData );
-        virtual void DirtyVertexFormat();
-        virtual void BindVertexFormat( FormatExtensionList* list, U16 fullCount, U16 vertexSize );
-        virtual void BindVertexOffset( U32 offset, U32 extraVertexCount );
+        virtual void BindVertexFormat( FormatExtensionList* list, U16 fullCount, U16 vertexSize, U32 offset );
         virtual void SetBlendEnabled( bool enabled );
         virtual void SetBlendFunction( const BlendMode& mode );
         virtual void SetBlendEquation( RenderTypes::BlendEquation mode );

--- a/librtt/Renderer/Rtt_GLGeometry.h
+++ b/librtt/Renderer/Rtt_GLGeometry.h
@@ -41,8 +41,6 @@ class GLGeometry : public GPUResource
         static void VertexAttribDivisor( GLuint index, GLuint divisor);
     
         bool StoredOnGPU() const { return !!fVBO; }
-        bool HasArrayObject() const { return !!fVAO; }
-        GLbyte* GetBaseOffset() const { return (GLbyte*)fPositionStart + fVertexOffset * sizeof(Geometry::Vertex); }
     
         void SpliceVertexRateData( const Geometry::Vertex* vertexData, Geometry::Vertex* extendedVertexData, const FormatExtensionList * list, size_t & size );
     
@@ -50,12 +48,10 @@ class GLGeometry : public GPUResource
         virtual void Update( CPUResource* resource );
         virtual void Destroy();
 
-        void BindStockAttributes( size_t size );
-        void SetVertexOffset( U32 offset, size_t sizeExtra, bool formatDirty );
+        void BindStockAttributes( size_t size, U32 offset );
 		void Bind();
 
-        void ResolveVertexFormat( const FormatExtensionList * list, U32 vertexSize, bool mainDirty, const Geometry::Vertex* instancingData, U32 instanceCount );
-        U32 GetVertexOffset() const { return fVertexOffset; }
+        void ResolveVertexFormat( const FormatExtensionList * list, U32 vertexSize, U32 offset, const Geometry::Vertex* instancingData, U32 instanceCount );
 
     private:
         GLvoid* fPositionStart;
@@ -68,7 +64,6 @@ class GLGeometry : public GPUResource
         GLuint fInstancesVBO;
         S32 fInstancesAllocated;
         U32 fVertexCount;
-        U32 fVertexOffset;
         U32 fIndexCount;
 };
 

--- a/librtt/Renderer/Rtt_Geometry_Renderer.cpp
+++ b/librtt/Renderer/Rtt_Geometry_Renderer.cpp
@@ -640,7 +640,7 @@ FormatExtensionList::Build( const CoronaVertexExtension * extension )
 }
 
 void
-FormatExtensionList::ReconcileFormats( CommandBuffer * buffer, const FormatExtensionList * shaderList, const FormatExtensionList * geometryList )
+FormatExtensionList::ReconcileFormats( CommandBuffer * buffer, const FormatExtensionList * shaderList, const FormatExtensionList * geometryList, U32 offset )
 {
     FormatExtensionList reconciledList = {};
     
@@ -684,7 +684,7 @@ FormatExtensionList::ReconcileFormats( CommandBuffer * buffer, const FormatExten
     
     U32 geometryAttributeCount = geometryList ? geometryList->attributeCount : 0;
     
-    buffer->BindVertexFormat( &reconciledList, geometryAttributeCount, FormatExtensionList::GetVertexSize( geometryList ) );
+    buffer->BindVertexFormat( &reconciledList, geometryAttributeCount, FormatExtensionList::GetVertexSize( geometryList ), offset );
 }
 
 FormatExtensionList::Iterator::Iterator( const FormatExtensionList* list, GroupFilter filter, IterationPolicy policy )

--- a/librtt/Renderer/Rtt_Geometry_Renderer.h
+++ b/librtt/Renderer/Rtt_Geometry_Renderer.h
@@ -277,7 +277,7 @@ struct FormatExtensionList {
     static size_t GetVertexSize( const FormatExtensionList * list );
     static bool Compatible( const FormatExtensionList * shaderList, const FormatExtensionList * geometryList );
     static bool Match( const FormatExtensionList * list1, const FormatExtensionList * list2 );
-    static void ReconcileFormats( CommandBuffer * buffer, const FormatExtensionList * shaderList, const FormatExtensionList * geometryList );
+    static void ReconcileFormats( CommandBuffer * buffer, const FormatExtensionList * shaderList, const FormatExtensionList * geometryList, U32 correction );
     
     void Build( const CoronaVertexExtension * extension );
     

--- a/librtt/Renderer/Rtt_Geometry_Renderer.h
+++ b/librtt/Renderer/Rtt_Geometry_Renderer.h
@@ -277,7 +277,7 @@ struct FormatExtensionList {
     static size_t GetVertexSize( const FormatExtensionList * list );
     static bool Compatible( const FormatExtensionList * shaderList, const FormatExtensionList * geometryList );
     static bool Match( const FormatExtensionList * list1, const FormatExtensionList * list2 );
-    static void ReconcileFormats( CommandBuffer * buffer, const FormatExtensionList * shaderList, const FormatExtensionList * geometryList, U32 correction );
+    static void ReconcileFormats( CommandBuffer * buffer, const FormatExtensionList * shaderList, const FormatExtensionList * geometryList, U32 offset );
     
     void Build( const CoronaVertexExtension * extension );
     

--- a/librtt/Renderer/Rtt_Renderer.h
+++ b/librtt/Renderer/Rtt_Renderer.h
@@ -368,6 +368,7 @@ class Renderer
         U32 fCachedVertexOffset;
         U32 fCachedVertexCount;
         U32 fCachedVertexExtra;
+		U32 fOffsetCorrection;
         Geometry::PrimitiveType fPreviousPrimitiveType;
         Geometry::Vertex* fCurrentVertex;
         Geometry* fCurrentGeometry;

--- a/librtt/Renderer/Rtt_VulkanCommandBuffer.h
+++ b/librtt/Renderer/Rtt_VulkanCommandBuffer.h
@@ -83,9 +83,7 @@ class VulkanCommandBuffer : public CommandBuffer
 		virtual void BindUniform( Uniform* uniform, U32 unit );
 		virtual void BindProgram( Program* program, Program::Version version );
         virtual void BindInstancing( U32 count, Geometry::Vertex* instanceData ) { Rtt_ASSERT_NOT_IMPLEMENTED(); }
-        virtual void DirtyVertexFormat() { Rtt_ASSERT_NOT_IMPLEMENTED(); }
-        virtual void BindVertexFormat( FormatExtensionList* extensionList, U16 fullCount, U16 vertexSize ) { Rtt_ASSERT_NOT_IMPLEMENTED(); }
-        virtual void BindVertexOffset( U32 offset, U32 extraVertexCount ) { Rtt_ASSERT_NOT_IMPLEMENTED(); }
+        virtual void BindVertexFormat( FormatExtensionList* extensionList, U16 fullCount, U16 vertexSize, U32 offset ) { Rtt_ASSERT_NOT_IMPLEMENTED(); }
 		virtual void SetBlendEnabled( bool enabled );
 		virtual void SetBlendFunction( const BlendMode& mode );
 		virtual void SetBlendEquation( RenderTypes::BlendEquation mode );


### PR DESCRIPTION
Android  (and maybe web, etc.) doesn't use vertex array objects, due from what I recall to some non-conforming devices. This has frustrated some of the logic behind changing vertex formats, including when to dirty them. And these are the fixes.

The implementation was admittedly a bit gnarly, and I noticed some of it also didn't benefit from living in command land, so where possible I moved logic back into `Rtt_Renderer::Insert()` and friends. I was also able to eliminate two commands entirely, as well as some state that was held between commands.

I'll try to do some further sanity tests tonight, but these now seem to work well both on the Android emulator and my phone: 
[Solar2D4.zip](https://github.com/coronalabs/corona/files/11127314/Solar2D4.zip), 
[Solar2D5.zip](https://github.com/coronalabs/corona/files/11127317/Solar2D5.zip)

--

I was told that the "don't cull / hit test" flags these depend on could impact performance (although under much heavier load), so will see about doing a little restructuring, and if successful piggyback the results in another PR I have planned.

Also, Solar by default is not loading a depth buffer (confusingly, some Android drivers will anyway). I loaded one (not included in the PR) to verify these tests, but will try to set up an opt-in approach through `config.lua` and submit that as well.