### PR TITLE
Spurious Flush() in display.capture()

### DIFF
--- a/librtt/Display/Rtt_Scene.cpp
+++ b/librtt/Display/Rtt_Scene.cpp
@@ -296,8 +296,6 @@ Scene::Render( Renderer& renderer, PlatformSurface& rTarget, DisplayObject& obje
 		object.Draw( renderer );
 		object.DidDraw( renderer );
 
-		rTarget.Flush();
-
 		fIsValid = true;
 	}
 }


### PR DESCRIPTION
Basically, `display.capture()` and friends seem to be the only cases where the second overload of `Scene::Render()` is called. From what I can tell these never need the `Flush()`; I believe it's just a copy-paste artifact.

It's a no-op on most platforms.[1] On Windows, though, it calls `SwapBuffers()`. You can see this if you try the `CaptureToFile` code sample, where you get a black image for a frame; without the `Flush()` you don't. From my admittedly foggy recollection the other exceptions were similar "end of frame" / vsync logic.

---

[1] - I'd have to review them to see where it isn't. I did the actual analysis almost a year ago, probably while investigating the Discord streaming crashes. I'm trying to distill a big diff into branches / PRs now, and had this on hand due to testing something or other with `display.capture()`.