### PR TITLE
Modifications to use application metadata for depth and stencil buffers

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/CoronaActivity.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaActivity.java
@@ -203,14 +203,22 @@ public class CoronaActivity extends Activity {
 		myInitialIntent = getIntent();
 
 		// Fetch this activity's meta-data from the manifest.
-		boolean isKeyboardAppPanningEnabled = false;
+		boolean isKeyboardAppPanningEnabled = false, wantsDepthBuffer = false, wantsStencilBuffer = false;
 		try {
+			android.content.pm.ApplicationInfo applicationInfo;
+			applicationInfo = getPackageManager().getApplicationInfo(
+					getPackageName(), android.content.pm.PackageManager.GET_META_DATA);
+			if (applicationInfo != null && applicationInfo.metaData != null) {
+				wantsDepthBuffer = applicationInfo.metaData.getBoolean( "wantsDepthBuffer" );
+				wantsStencilBuffer = applicationInfo.metaData.getBoolean( "wantsStencilBuffer" );
+			}
 			android.content.pm.ActivityInfo activityInfo;
 			activityInfo = getPackageManager().getActivityInfo(
 					getComponentName(), android.content.pm.PackageManager.GET_META_DATA);
 			if ((activityInfo != null) && (activityInfo.metaData != null)) {
 				isKeyboardAppPanningEnabled =
 						activityInfo.metaData.getBoolean("coronaWindowMovesWhenKeyboardAppears");
+
 			}
 		}
 		catch (Exception ex) {
@@ -249,7 +257,7 @@ public class CoronaActivity extends Activity {
 		CoronaEnvironment.setCoronaActivity(this);
 
 		// Create our CoronaRuntime, which also initializes the native side of the CoronaRuntime.
-		fCoronaRuntime = new CoronaRuntime(this, false);
+		fCoronaRuntime = new CoronaRuntime(this, false, wantsDepthBuffer, wantsStencilBuffer);
 
 		// Set initialSystemUiVisibility before splashScreen comes up
 		try {

--- a/platform/android/sdk/src/com/ansca/corona/CoronaRuntime.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaRuntime.java
@@ -44,13 +44,13 @@ public class CoronaRuntime {
 	 * <p>
 	 * This constructor was made internal so that only the Corona can make instances of this class.
 	 */
-	CoronaRuntime(android.content.Context context, boolean isCoronaKit) {
+	CoronaRuntime(android.content.Context context, boolean isCoronaKit, boolean wantsDepthBuffer, boolean wantsStencilBuffer) {
 		fLuaState = null;
 		fWasDisposed = false;
 		fTaskDispatcher = new CoronaRuntimeTaskDispatcher(this);
 		fBaseDir = "";
 		fIsCoronaKit = isCoronaKit;
-		fGLView = new com.ansca.corona.graphics.opengl.CoronaGLSurfaceView(context, this, isCoronaKit);
+		fGLView = new com.ansca.corona.graphics.opengl.CoronaGLSurfaceView(context, this, isCoronaKit, wantsDepthBuffer, wantsStencilBuffer);
 
 		// Initialize the native side of the Corona runtime.
 		// Note that this does not load and start the Corona project.
@@ -64,7 +64,7 @@ public class CoronaRuntime {
 	}
 	
 	void reset(android.content.Context context) {
-		fGLView = new com.ansca.corona.graphics.opengl.CoronaGLSurfaceView(context, this, true);
+		fGLView = new com.ansca.corona.graphics.opengl.CoronaGLSurfaceView(context, this, true, false, false);
 		fController.setGLView(fGLView);
 		fViewManager.setGLView(fGLView);
 	}

--- a/platform/android/sdk/src/com/ansca/corona/CoronaView.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaView.java
@@ -134,7 +134,7 @@ public class CoronaView extends FrameLayout {
 			fCoronaRuntime.reset(getContext());
 		} else {
 			// We didn't save a valid address, so we need a new CoronaRuntime
-			fCoronaRuntime = new CoronaRuntime(getContext(), true);
+			fCoronaRuntime = new CoronaRuntime(getContext(), true, false, false);
 		}
 		fInputHandler.setView(fCoronaRuntime.getViewManager().getContentView());
 		fInputHandler.setDispatcher(fCoronaRuntime.getTaskDispatcher());
@@ -193,7 +193,7 @@ public class CoronaView extends FrameLayout {
 			Looper.prepare();
 		}
 
-		fCoronaRuntime = new CoronaRuntime(getContext(), true);
+		fCoronaRuntime = new CoronaRuntime(getContext(), true, false, false);
 
 		if (!baseDir.endsWith("/")) {
 			baseDir = baseDir + "/";

--- a/platform/android/sdk/src/com/ansca/corona/graphics/opengl/CoronaGLSurfaceView.java
+++ b/platform/android/sdk/src/com/ansca/corona/graphics/opengl/CoronaGLSurfaceView.java
@@ -48,7 +48,7 @@ public class CoronaGLSurfaceView extends GLSurfaceView {
 	 * Creates a new OpenGL surface used to render Corona's content.
 	 * @param context Reference to the context. Cannot be null.
 	 */
-	public CoronaGLSurfaceView(android.content.Context context, com.ansca.corona.CoronaRuntime runtime, boolean isCoronaKit) {
+	public CoronaGLSurfaceView(android.content.Context context, com.ansca.corona.CoronaRuntime runtime, boolean isCoronaKit, boolean wantsDepthBuffer, boolean wantsStencilBuffer) {
 		super(context);
 
 		// Validate.
@@ -138,7 +138,15 @@ public class CoronaGLSurfaceView extends GLSurfaceView {
 		// Note: The alpha channel must be disabled for the "surface" to work-around an OpenGL driver bug on Kindle Fire
 		//       and Nook Tablet where all alpha blended polygons, including the GL clear color, will be blended with black.
 		//       Alpha blending of content will still work because of the 32-bit color PixelFormat set down below.
-		setEGLConfigChooser(8, 8, 8, 8, 0, 0);
+		if (wantsStencilBuffer)
+		{
+			wantsDepthBuffer = true;
+		}
+
+		int depthSize = wantsDepthBuffer ? 16 : 0;
+		int stencilSize = wantsStencilBuffer ? 8 : 0;
+
+		setEGLConfigChooser(8, 8, 8, 8, depthSize, stencilSize);
 
 		// Attach the renderer to the surface.
 		fRenderer = new CoronaRenderer(this, runtime, isCoronaKit);


### PR DESCRIPTION
A couple of my tests for the experimental build were working on the Android emulator (`Pixel_3a_API_31_arm64-v8a`, chosen arbitrarily) but not on an actual device (Neffos x9 or so, v7 architecture I believe).

The `eglConfigChooser()` call was not requesting depth (or stencil) bits, although it seems some drivers are generous.

These modifications let you ask for a depth buffer and it will modify that request accordingly.

At the moment this is a simple "I want it", in which case it gives you a 16-bit depth buffer. (If you request a stencil buffer, which will be 8 bits, it will also throw the 16-bit depth buffer in, since these always seem to go hand-in-hand.)

Perhaps some refinement could follow later, e.g. for 24-bit depth, although it would probably have to query for capabilities or pixel formats.

The options are **"wantsDepthBuffer"** and **"wantsStencilBuffer"**, which you can provide in `build.settings` like so:

```
	android =
	{
		applicationChildElements = {
			[[<meta-data android:name="wantsDepthBuffer" android:value="true" />]]
		}
	}
```

This gave me appropriate on-device results with that setting and without it.

---

I haven't run into the same need on Windows, Mac, iOS, or tvOS in my tests (these last two in their respective emulators), but they'd call for something similar if it should arise.

---

**TODO?**

I wasn't sure if I could trip those code paths that pass `false, false` when constructing `fView` and `fCoronaRuntime`.