### PR TITLE
MacOS: Fix crash with display.capture()

### DIFF
--- a/platform/mac/GLView.mm
+++ b/platform/mac/GLView.mm
@@ -364,8 +364,10 @@ NSOpenGLPixelFormatAttribute attributes1 [] = {
 	{
 		fRuntime->Render();
 	}
+    if([self openGLContext]){
+        [[self openGLContext] flushBuffer];
+    }
     
-    [[self openGLContext] flushBuffer];
 }
 
 - (void)setDelegate:(id< GLViewDelegate >)delegate


### PR DESCRIPTION
Fixes #545