### PR TITLE
Fix for leak in prototypes' ShaderData

### DIFF
--- a/librtt/Display/Rtt_ShaderData.cpp
+++ b/librtt/Display/Rtt_ShaderData.cpp
@@ -44,6 +44,11 @@ ShaderData::~ShaderData()
 	{
 		fProxy->DetachUserdata();
 	}
+
+	for ( int i = 0; i < kNumData; i++ )
+	{
+		Rtt_DELETE( fUniformData[i] );
+	}
 }
 
 void
@@ -62,6 +67,8 @@ ShaderData::QueueRelease( DisplayObject *observer )
 	for ( int i = 0; i < kNumData; i++ )
 	{
 		observer->QueueRelease( fUniformData[i] );
+
+		fUniformData[i] = NULL;
 	}
 	observer->QueueRelease( fProxy );
 }


### PR DESCRIPTION
I was getting reports of this while doing some other tests in Debug on Windows.

You seem to get two leaks per uniform used by an effect (after first assignment), which I'm guessing belong to the two shader mods. Proper instances cloned off of these were being shuttled into the orphanage and then cleaned up, as expected, but nothing was accounting for the originals.

---

There seemed to be [some awareness of the situation](https://github.com/coronalabs/corona/blob/master/librtt/Display/Rtt_ShaderResource.cpp#L94), but I guess it slipped through the cracks.