### PR TITLE
Remove Xcode 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,54 +153,8 @@ jobs:
           path: ./output
 
 
-  Xcode-template-matrix:
-    strategy:
-      matrix:
-        runner:
-          - macos-11
-        xcode:
-          - Xcode_13.2.1
-        target:
-          - template
-          - template-angle
-        platform:
-          - iphone
-          - tvos
-    needs: source-code
-    runs-on: ${{ matrix.runner }}
-    env:
-      DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
-      TEMPLATE_TARGET: ${{ matrix.target }}
-      TEMPLATE_PLATFORM: ${{ matrix.platform }}
-      S2D_MIN_VER_IOS: "8.0"
-      S2D_MIN_VER_TVOS: "9.0"
-      S2D_MIN_VER_MACOS: "10.9"
-    steps:
-      - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
-      - name: Get processed code
-        uses: actions/download-artifact@v1
-        with:
-          name: SourceCode
-      - name: Unpack source code
-        run: tar -xzf SourceCode/corona.tgz
-      - run: ./tools/GHAction/daily_env.sh
-      - name: Build templates
-        working-directory: ./platform/${{ matrix.platform }}
-        run: ./gh_build_templates.sh
-        env:
-          CERT_PASSWORD: ${{ secrets.CertPassword }}
-      - name: Build templates JSON spec
-        run: ./tools/GHAction/generate_xcode_jsons.py
-      - name: Upload templates
-        uses: actions/upload-artifact@v1
-        with:
-          name: Templates-${{ matrix.platform }}-${{ matrix.xcode }}-${{ matrix.target }}
-          path: ./output
-
-
   collect-ios-templates:
     needs:
-      - Xcode-template-matrix
       - Xcode-template-matrix-12
       - Xcode-template-matrix-13
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Remove Xcode 13.2.1 since Apple is removing support for this "Starting April 25, 2023, iOS, iPadOS, and watchOS apps submitted to the App Store must be built with Xcode 14.1 or later. The latest version of Xcode 14, which includes the latest SDKs for iOS 16, iPadOS 16"
https://developer.apple.com/news/?id=jd9wcyov