### PR TITLE
iOS: Add Clear Button Mode for iOS

### DIFF
--- a/platform/iphone/Rtt_IPhoneTextFieldObject.mm
+++ b/platform/iphone/Rtt_IPhoneTextFieldObject.mm
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 // This file is part of the Corona game engine.
-// For overview and more information on licensing please refer to README.md 
+// For overview and more information on licensing please refer to README.md
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
 //
@@ -270,6 +270,57 @@ StringForUITextSpellCheckingType( UITextSpellCheckingType value )
 
 // ----------------------------------------------------------------------------
 
+static const char kUITextClearButtonModeDefaultString[] = "UITextClearButtonModeNever";
+static const char kUITextClearButtonModeWhileEditingString[] = "UITextClearButtonModeWhileEditing";
+static const char kUITextClearButtonModeUnlessEditingString[] = "UITextClearButtonModeUnlessEditing";
+static const char kUITextClearButtonModeModeAlwaystring[] = "UITextClearButtonModeAlways";
+
+static UITextFieldViewMode
+UITextClearButtonModeForString( const char *value )
+{
+	UITextFieldViewMode result = UITextFieldViewModeNever;
+
+	if ( 0 == strcmp( value, kUITextClearButtonModeWhileEditingString ) )
+	{
+		result = UITextFieldViewModeWhileEditing;
+	}
+	else if ( 0 == strcmp( value, kUITextClearButtonModeUnlessEditingString ) )
+	{
+		result = UITextFieldViewModeUnlessEditing;
+	}
+	else if ( 0 == strcmp( value, kUITextClearButtonModeModeAlwaystring ) )
+	{
+		result = UITextFieldViewModeAlways;
+	}
+
+	return result;
+}
+
+static const char *
+StringForUITextClearButtonModeType( UITextSpellCheckingType value )
+{
+	const char *result = kUITextClearButtonModeDefaultString;
+
+	switch( value )
+	{
+		case UITextFieldViewModeWhileEditing:
+			result = kUITextClearButtonModeWhileEditingString;
+			break;
+		case UITextFieldViewModeUnlessEditing:
+			result = kUITextClearButtonModeUnlessEditingString;
+			break;
+		case UITextFieldViewModeAlways:
+			result = kUITextClearButtonModeModeAlwaystring;
+			break;
+		default:
+			break;
+	}
+
+	return result;
+}
+
+// ----------------------------------------------------------------------------
+
 IPhoneTextFieldObject::IPhoneTextFieldObject( const Rect& bounds )
 :	Super( bounds ),
 	fIsFontSizeScaled( true )
@@ -347,7 +398,7 @@ IPhoneTextFieldObject::setTextColor( lua_State *L )
 
 	return 0;
 }
-    
+
 int
 IPhoneTextFieldObject::setReturnKey( lua_State *L )
 {
@@ -355,12 +406,12 @@ IPhoneTextFieldObject::setReturnKey( lua_State *L )
     if ( & o->ProxyVTable() == & PlatformDisplayObject::GetTextFieldObjectProxyVTable() )
     {
         const char* imeType = lua_tostring(L, -1);
-            
+
         UIView *v = ((IPhoneTextFieldObject*)o)->GetView();
         Rtt_UITextField *t = (Rtt_UITextField*)v;
         t.returnKeyType = IPhoneText::GetUIReturnKeyTypeFromIMEType(imeType);
     }
-        
+
     return 0;
 }
 
@@ -372,7 +423,7 @@ IPhoneTextFieldObject::setSelection( lua_State *L )
 	{
 		double startPosition = lua_tonumber(L, 2);
 		double endPosition = lua_tonumber(L, 3);
-		
+
 		UIView *v = ((IPhoneTextFieldObject*)o)->GetView();
 		Rtt_UITextField *t = (Rtt_UITextField*)v;
 
@@ -382,12 +433,12 @@ IPhoneTextFieldObject::setSelection( lua_State *L )
 			startPosition = maxLength;
 			endPosition = maxLength;
 		}
-		
+
 		if (endPosition > maxLength)
 		{
 			endPosition = maxLength;
 		}
-		
+
 		if (startPosition < 0)
 		{
 			startPosition = 0;
@@ -397,23 +448,23 @@ IPhoneTextFieldObject::setSelection( lua_State *L )
 		{
 			endPosition = 0;
 		}
-		
+
 		if (startPosition > endPosition)
 		{
 			startPosition = endPosition;
 		}
-		
+
 		UITextPosition *beginning = t.beginningOfDocument;
 		UITextPosition *start = [t positionFromPosition:beginning offset:startPosition];
 		UITextPosition *end = [t positionFromPosition:beginning offset:endPosition];
 		UITextRange *textRange = [t textRangeFromPosition:start toPosition:end];
-		
+
 		t.selectedTextRange = textRange;
 	}
-	
+
 	return 0;
 }
-	
+
 int
 IPhoneTextFieldObject::ValueForKey( lua_State *L, const char key[] ) const
 {
@@ -510,6 +561,11 @@ IPhoneTextFieldObject::ValueForKey( lua_State *L, const char key[] ) const
 	else if ( strcmp( "spellCheckingType", key ) == 0 )
 	{
 		const char *value = StringForUITextSpellCheckingType( t.spellCheckingType );
+		lua_pushstring( L, value );
+	}
+	else if ( strcmp( "clearButtonMode", key ) == 0 )
+	{
+		const char *value = StringForUITextClearButtonModeType( t.clearButtonMode );
 		lua_pushstring( L, value );
 	}
 	else if ( strcmp( "margin", key ) == 0 )
@@ -665,6 +721,13 @@ IPhoneTextFieldObject::SetValueForKey( lua_State *L, const char key[], int value
 		UITextSpellCheckingType newValue = UITextSpellCheckingTypeForString( value );
 		t.spellCheckingType = newValue;
 	}
+	else if ( strcmp( "clearButtonMode", key ) == 0 )
+	{
+		const char *value = lua_tostring( L, valueIndex );
+
+		UITextClearButtonMode newValue = UITextClearButtonModeForString( value );
+		t.clearButtonMode = newValue;
+	}
 	else
 	{
 		// Custom step for UITextField
@@ -673,7 +736,7 @@ IPhoneTextFieldObject::SetValueForKey( lua_State *L, const char key[], int value
 			BOOL hasBackground = (BOOL)lua_toboolean( L, valueIndex );
 			t.borderStyle = ( hasBackground ? UITextBorderStyleRoundedRect : UITextBorderStyleNone );
 		}
-	
+
 		result = Super::SetValueForKey( L, key, valueIndex );
 	}
 

--- a/platform/iphone/Rtt_IPhoneTextFieldObject.mm
+++ b/platform/iphone/Rtt_IPhoneTextFieldObject.mm
@@ -297,7 +297,7 @@ UITextClearButtonModeForString( const char *value )
 }
 
 static const char *
-StringForUITextClearButtonModeType( UITextSpellCheckingType value )
+StringForUITextClearButtonModeType( UITextFieldViewMode value )
 {
 	const char *result = kUITextClearButtonModeDefaultString;
 
@@ -725,7 +725,7 @@ IPhoneTextFieldObject::SetValueForKey( lua_State *L, const char key[], int value
 	{
 		const char *value = lua_tostring( L, valueIndex );
 
-		UITextClearButtonMode newValue = UITextClearButtonModeForString( value );
+        UITextFieldViewMode newValue = UITextClearButtonModeForString( value );
 		t.clearButtonMode = newValue;
 	}
 	else

--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 // This file is part of the Corona game engine.
-// For overview and more information on licensing please refer to README.md 
+// For overview and more information on licensing please refer to README.md
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
 //
@@ -314,7 +314,7 @@ int WinTextBoxObject::ValueForKey(lua_State *L, const char key[]) const
 			lua_pushstring(L, utf8Text);
 		}
 	}
-	else if (!strcmp("autocorrectionType", key) || !strcmp("spellCheckingType", key))
+	else if (!strcmp("autocorrectionType", key) || !strcmp("spellCheckingType", key) || !strcmp("clearButtonMode", key))
 	{
 		if (fIsSingleLine)
 		{
@@ -573,7 +573,7 @@ bool WinTextBoxObject::SetValueForKey(lua_State *L, const char key[], int valueI
 					fIsSingleLine ? "TextField" : "TextBox", key);
 		}
 	}
-	else if (!strcmp("autocorrectionType", key) || !strcmp("spellCheckingType", key))
+	else if (!strcmp("autocorrectionType", key) || !strcmp("spellCheckingType", key) || !strcmp("clearButtonMode", key))
 	{
 		if (fIsSingleLine)
 		{


### PR DESCRIPTION
based on issue #370

`
local field = native.newTextField( 50, 150, 220, 36 )
--field.clearButtonMode = "UITextClearButtonModeNever" -- default
field.clearButtonMode = "UITextClearButtonModeWhileEditing"
--field.clearButtonMode = "UITextClearButtonModeUnlessEditing"
--field.clearButtonMode = "UITextClearButtonModeAlways"
`