### PR TITLE
Core: Fixes for Display Color Sample

### DIFF
--- a/librtt/Display/Rtt_Display.cpp
+++ b/librtt/Display/Rtt_Display.cpp
@@ -792,20 +792,20 @@ Display::Capture( DisplayObject *object,
     Rtt_Real y_in_pixels = 0;
     Rtt_Real w_in_pixels = w_in_content_units;
     Rtt_Real h_in_pixels = h_in_content_units;
-    {
+    if(!optional_output_color){
 
         ContentToScreen( x_in_pixels,
-                            y_in_pixels,
-                            w_in_pixels,
-                            h_in_pixels );
+                        y_in_pixels,
+                        w_in_pixels,
+                        h_in_pixels);
 
         // We ONLY want the w_in_pixels and h_in_pixels.
         // Using anything but 0 here breaks Android.
         x_in_pixels = 0;
         y_in_pixels = 0;
     }
-    printf("run13/ %.6f \n", w_in_pixels);
-    printf("run13/ %.6f \n", h_in_pixels);
+
+    
 #    if defined( Rtt_OPENGLES )
         const Texture::Format kFormat = Texture::kRGBA;
 #    else

--- a/librtt/Display/Rtt_LuaLibDisplay.cpp
+++ b/librtt/Display/Rtt_LuaLibDisplay.cpp
@@ -2515,14 +2515,14 @@ DisplayLibrary::colorSample( lua_State *L )
 	LuaResource *resource = Rtt_NEW( LuaContext::GetAllocator( L ),
 										LuaResource( LuaContext::GetContext( L )->LuaState(),
 														3 /*!< Callback index. */ ) );
-
 	RGBA color;
 	color.Clear();
-
+    
 	display.ColorSample( pos_x,
 							pos_y,
 							color );
-
+    display.Render(); // rerender if no texture has been created
+    
 	ColorSampleEvent e( pos_x,
 							pos_y,
 							color );


### PR DESCRIPTION
We don't want to run "ContentToScreen" with color output because w and h are 1 those could be rounded down to 0 on certain screen sizes.
I also noticed the same crash as with display.capture() some times, rerendering after call seems to fix the issue. Can remove that piece if needed