### PR TITLE
iOS: resolving issue with CoronaBuilder

### DIFF
--- a/platform/resources/iPhonePackageApp.lua
+++ b/platform/resources/iPhonePackageApp.lua
@@ -962,6 +962,12 @@ local function packageApp( options )
 		end
 	end
 
+	--remove standard resources(Corona Resources Bundle) if users selects
+
+	if options.includeStandardResources == false then
+		runScript("rm -rf "..quoteString(makepath(appBundleFileUnquoted, "CoronaResources.bundle")))
+	end
+
 	-- bundle is now ready to be signed (don't sign if we don't have a signingIdentity, e.g. Xcode Simulator)
 	if options.signingIdentity then
 		-- codesign embedded frameworks before signing the .app
@@ -996,12 +1002,6 @@ local function packageApp( options )
 	end
 
 	runScript( "chmod 755 " .. appBundleFile )
-
-	--remove standard resources(Corona Resources Bundle) if users selects
-
-	if options.includeStandardResources == false then
-		runScript("rm -rf "..quoteString(makepath(appBundleFileUnquoted, "CoronaResources.bundle")))
-	end
 
 	-- If building with a distribution identity, create an IPA of the .app which can be used by Application Loader
 	local appBundleFileIPA = quoteString(makepath(options.dstDir, options.dstFile) .. ".ipa")

--- a/platform/shared/Rtt_PlatformAppPackager.h
+++ b/platform/shared/Rtt_PlatformAppPackager.h
@@ -58,7 +58,7 @@ class AppPackagerParams
 		bool fIncludeFusePlugins;
 		bool fUsesMonetization;
 		bool fLiveBuild;
-        bool fIncludeStandardResources;
+        bool fIncludeStandardResources = true;
 		String fCoronaUser;
 
 	public:

--- a/tools/CoronaBuilder/Rtt_AppPackagerAppleFactory.mm
+++ b/tools/CoronaBuilder/Rtt_AppPackagerAppleFactory.mm
@@ -219,6 +219,11 @@ AppPackagerFactory::CreatePackagerParamsApple(
 			break;
 	}
 	
+	if ( ! result )
+	{
+		fprintf( stderr, "ERROR: Unsupported platform: %s\n", TargetDevice::StringForPlatform( targetPlatform ) );
+	}
+	
 	lua_getfield(L, index, "customTemplate" );
 	if(lua_type(L, -1) == LUA_TSTRING)
 	{
@@ -226,10 +231,12 @@ AppPackagerFactory::CreatePackagerParamsApple(
 	}
 	lua_pop(L, 1);
 
-	if ( ! result )
+	lua_getfield(L, index, "includeStandardResources");
+	if(lua_type(L, -1) == LUA_TBOOLEAN)
 	{
-		fprintf( stderr, "ERROR: Unsupported platform: %s\n", TargetDevice::StringForPlatform( targetPlatform ) );
+		result->SetIncludeStandardResources(lua_toboolean(L, -1));
 	}
+	lua_pop(L, 1);
 
 	return result;
 }

--- a/tools/CoronaBuilder/Rtt_AppPackagerLinuxFactory.cpp
+++ b/tools/CoronaBuilder/Rtt_AppPackagerLinuxFactory.cpp
@@ -45,7 +45,7 @@ namespace Rtt
 		}
 
 		bool includeStandardResources = true;
-		lua_getfield(L, index, "includeWidgetResources");
+		lua_getfield(L, index, "includeStandardResources");
 		if(lua_type(L, -1) == LUA_TBOOLEAN)
 		{
 			includeStandardResources = lua_toboolean(L, -1);


### PR DESCRIPTION
Fixes #577

Issue was that we were removing resources by default, and code-signing before removing them. Changed default no to remove, also added option `includeStandardResources` to iOS builder