### PR TITLE
Update webView for câmera access.

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/CoronaWebView.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaWebView.java
@@ -13,6 +13,8 @@ import android.content.Context;
 import android.graphics.Color;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.webkit.WebSettings;
+import android.webkit.PermissionRequest;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;


### PR DESCRIPTION
The webView cant launch camera from inside it. We need to transfer the necessary permissions so the webview can have access to it.
This code is necessary on android studios so the camera can be opened inside the webview.