### PR TITLE
Added getSelection for native.textField

### DIFF
--- a/platform/android/ndk/Rtt_AndroidTextFieldObject.cpp
+++ b/platform/android/ndk/Rtt_AndroidTextFieldObject.cpp
@@ -125,6 +125,26 @@ AndroidTextFieldObject::setSelection( lua_State *L )
 	return 0;
 }
 
+int
+AndroidTextFieldObject::getSelection( lua_State *L )
+{
+    PlatformDisplayObject *o = (PlatformDisplayObject*)LuaProxy::GetProxyableObject(L, 1);
+    if (&o->ProxyVTable() == &PlatformDisplayObject::GetTextFieldObjectProxyVTable())
+    {
+        NativeToJavaBridge *bridge = (NativeToJavaBridge*)lua_touserdata(L, lua_upvalueindex(1));
+
+        int startPosition, endPosition;
+        if (bridge->TextFieldGetSelection(((AndroidDisplayObject*)o)->GetId(), startPosition, endPosition))
+        {
+            lua_pushnumber(L, startPosition);
+            lua_pushnumber(L, endPosition);
+            return 2;
+        }
+    }
+
+    return 0;
+}
+
 // TODO: move these somewhere in librtt, so all platforms use same constants
 static const char kDefaultInputType[] = "default";
 static const char kUrlInputType[] = "url";
@@ -198,6 +218,11 @@ AndroidTextFieldObject::ValueForKey( lua_State *L, const char key[] ) const
 	{
 		lua_pushlightuserdata( L, fNativeToJavaBridge );
 		lua_pushcclosure( L, setSelection, 1 );
+	}
+	else if ( strcmp( "getSelection", key ) == 0 )
+	{
+		lua_pushlightuserdata( L, fNativeToJavaBridge );
+		lua_pushcclosure( L, getSelection, 1 );
 	}
 	else if ( strcmp( "align", key ) == 0 )
 	{

--- a/platform/android/ndk/Rtt_AndroidTextFieldObject.h
+++ b/platform/android/ndk/Rtt_AndroidTextFieldObject.h
@@ -45,6 +45,7 @@ class AndroidTextFieldObject : public AndroidDisplayObject
 		static int setTextColor( lua_State *L );
 		static int setReturnKey( lua_State *L );
 		static int setSelection( lua_State *L );
+		static int getSelection( lua_State *L );
 
 	public:
 		// MLuaTableBridge

--- a/platform/android/ndk/jni/NativeToJavaBridge.cpp
+++ b/platform/android/ndk/jni/NativeToJavaBridge.cpp
@@ -2370,6 +2370,35 @@ NativeToJavaBridge::TextFieldSetSelection( int id, int startPosition, int endPos
 	}
 }
 
+bool
+NativeToJavaBridge::TextFieldGetSelection(int id, int& startPosition, int& endPosition)
+{
+	NativeTrace trace("NativeToJavaBridge::TextFieldGetSelection");
+
+	jclassInstance bridge(GetJNIEnv(), kNativeToJavaBridge);
+	startPosition = -1;
+	endPosition = -1;
+
+	if (bridge.isValid()) {
+		jmethodID mid = bridge.getEnv()->GetStaticMethodID(bridge.getClass(),
+			"callTextFieldGetSelection", "(Lcom/ansca/corona/CoronaRuntime;I)[I");
+
+		if (mid != NULL) {
+			jintArray result = (jintArray)bridge.getEnv()->CallStaticObjectMethod(bridge.getClass(), mid, fCoronaRuntime, id);
+			HandleJavaException();
+
+			if (result != NULL) {
+				jint* elements = bridge.getEnv()->GetIntArrayElements(result, 0);
+				startPosition = elements[0];
+				endPosition = elements[1];
+				bridge.getEnv()->ReleaseIntArrayElements(result, elements, 0);
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 void
 NativeToJavaBridge::TextFieldSetPlaceholder( int id, const char * placeholder )
 {

--- a/platform/android/ndk/jni/NativeToJavaBridge.h
+++ b/platform/android/ndk/jni/NativeToJavaBridge.h
@@ -195,6 +195,7 @@ class NativeToJavaBridge
 		int TextFieldCreate( int id, int left, int top, int width, int height, int isSingleLine );
 		void TextFieldSetReturnKey( int id, const char * imeType );
 		void TextFieldSetSelection( int id, int startPosition, int endPosition );
+		bool TextFieldGetSelection(int id, int& startPosition, int& endPosition);
 		void TextFieldSetPlaceholder( int id, const char * placeholder );
 		void TextFieldSetColor( int id, int r, int g, int b, int a );
 		void TextFieldSetText( int id, const char * text );

--- a/platform/android/sdk/src/com/ansca/corona/NativeToJavaBridge.java
+++ b/platform/android/sdk/src/com/ansca/corona/NativeToJavaBridge.java
@@ -2307,6 +2307,10 @@ public class NativeToJavaBridge {
 		runtime.getViewManager().setTextSelection( id, startPosition, endPosition );
 	}
 
+	protected static int[] callTextFieldGetSelection(CoronaRuntime runtime, int id) {
+	    return runtime.getViewManager().getTextSelection(id);
+	}
+
 	protected static void callTextFieldSetReturnKey( CoronaRuntime runtime, int id, String imeType ) 
 	{
 		runtime.getViewManager().setTextReturnKey( id, imeType );

--- a/platform/android/sdk/src/com/ansca/corona/ViewManager.java
+++ b/platform/android/sdk/src/com/ansca/corona/ViewManager.java
@@ -481,6 +481,43 @@ public class ViewManager {
 		} );
 	}
 
+	public int[] getTextSelection(final int id) {
+	    final int[] result = new int[2];
+	    final Object lock = new Object();
+
+	    Runnable runnable = new Runnable() {
+	        @Override
+	        public void run() {
+	            CoronaEditText view = getDisplayObjectById(CoronaEditText.class, id);
+	            if (view != null) {
+	                result[0] = view.getSelectionStart();
+	                result[1] = view.getSelectionEnd();
+	            } else {
+	                result[0] = -1;
+	                result[1] = -1;
+	            }
+	            synchronized (lock) {
+	                lock.notify();
+	            }
+	        }
+	    };
+
+	    if (Thread.currentThread() == Looper.getMainLooper().getThread()) {
+	        runnable.run();
+	    } else {
+	        synchronized (lock) {
+	            postOnUiThread(runnable);
+	            try {
+	                lock.wait();
+	            } catch (InterruptedException e) {
+	                e.printStackTrace();
+	            }
+	        }
+	    }
+
+	    return result;
+	}
+
 	public void setTextViewColor( final int id, final int color )
 	{
 		postOnUiThread( new Runnable() {

--- a/platform/iphone/Rtt_IPhoneTextBoxObject.h
+++ b/platform/iphone/Rtt_IPhoneTextBoxObject.h
@@ -44,6 +44,7 @@ class IPhoneTextBoxObject : public IPhoneDisplayObject
 		static int setTextColor( lua_State *L );
         static int setReturnKey( lua_State *L );
 		static int setSelection( lua_State *L );
+		static int getSelection( lua_State *L );
 
 	public:
 		// MLuaTableBridge

--- a/platform/iphone/Rtt_IPhoneTextBoxObject.mm
+++ b/platform/iphone/Rtt_IPhoneTextBoxObject.mm
@@ -265,6 +265,26 @@ IPhoneTextBoxObject::setSelection( lua_State *L )
 	
 	return 0;
 }
+
+int
+IPhoneTextBoxObject::getSelection(lua_State *L)
+{
+	PlatformDisplayObject *o = (PlatformDisplayObject*)LuaProxy::GetProxyableObject(L, 1);
+	if (&o->ProxyVTable() == &PlatformDisplayObject::GetTextBoxObjectProxyVTable())
+	{
+		UIView *v = ((IPhoneTextBoxObject*)o)->GetView();
+		Rtt_UITextView *t = (Rtt_UITextView*)v;
+
+		NSRange range = t.selectedRange;
+
+		lua_pushnumber(L, range.location);
+		lua_pushnumber(L, range.location + range.length);
+		
+		return 2;
+	}
+
+	return 0;
+}
 	
 int
 IPhoneTextBoxObject::ValueForKey( lua_State *L, const char key[] ) const
@@ -326,6 +346,10 @@ IPhoneTextBoxObject::ValueForKey( lua_State *L, const char key[] ) const
 	else if ( strcmp( "setSelection", key) == 0 )
 	{
 		lua_pushcfunction( L, setSelection );
+	}
+	else if ( strcmp( "getSelection", key) == 0 )
+	{
+		lua_pushcfunction( L, getSelection );
 	}
 	else if ( strcmp( "align", key ) == 0 )
 	{

--- a/platform/iphone/Rtt_IPhoneTextFieldObject.h
+++ b/platform/iphone/Rtt_IPhoneTextFieldObject.h
@@ -45,6 +45,7 @@ class IPhoneTextFieldObject : public IPhoneDisplayObject
 		static int setTextColor( lua_State *L );
         static int setReturnKey( lua_State *L );
         static int setSelection( lua_State *L );
+        static int getSelection( lua_State *L );
 
 	public:
 		bool rejectEmoji(const char *str);

--- a/platform/iphone/Rtt_IPhoneTextFieldObject.mm
+++ b/platform/iphone/Rtt_IPhoneTextFieldObject.mm
@@ -466,6 +466,29 @@ IPhoneTextFieldObject::setSelection( lua_State *L )
 }
 
 int
+IPhoneTextFieldObject::getSelection(lua_State *L)
+{
+	PlatformDisplayObject *o = (PlatformDisplayObject*)LuaProxy::GetProxyableObject(L, 1);
+	if (&o->ProxyVTable() == &PlatformDisplayObject::GetTextFieldObjectProxyVTable())
+	{
+		UIView *v = ((IPhoneTextFieldObject*)o)->GetView();
+		Rtt_UITextField *t = (Rtt_UITextField*)v;
+
+		UITextRange *selectedRange = t.selectedTextRange;
+	
+		NSInteger startPosition = [t offsetFromPosition:t.beginningOfDocument toPosition:selectedRange.start];
+		NSInteger endPosition = [t offsetFromPosition:t.beginningOfDocument toPosition:selectedRange.end];
+
+		lua_pushnumber(L, startPosition);
+		lua_pushnumber(L, endPosition);
+		
+		return 2;
+	}
+
+	return 0;
+}
+
+int
 IPhoneTextFieldObject::ValueForKey( lua_State *L, const char key[] ) const
 {
 	Rtt_ASSERT( key );
@@ -517,6 +540,10 @@ IPhoneTextFieldObject::ValueForKey( lua_State *L, const char key[] ) const
 	else if ( strcmp( "setSelection", key ) == 0 )
 	{
 		lua_pushcfunction( L, setSelection );
+	}
+	else if ( strcmp( "getSelection", key ) == 0 )
+	{
+		lua_pushcfunction( L, getSelection );
 	}
 	else if ( strcmp( "align", key ) == 0 )
 	{

--- a/platform/linux/src/Rtt_LinuxTextBoxObject.cpp
+++ b/platform/linux/src/Rtt_LinuxTextBoxObject.cpp
@@ -102,6 +102,10 @@ namespace Rtt
 		{
 			lua_pushcfunction(L, SetSelection);
 		}
+		else if (strcmp("getSelection", key) == 0)
+		{
+			lua_pushcfunction(L, GetSelection);
+		}
 		else if (strcmp("align", key) == 0)
 		{
 			char buf[16] = { 0 };
@@ -274,6 +278,12 @@ namespace Rtt
 	{
 		Rtt_LogException("LinuxTextBoxObject:SetSelection() is not implemented\n");
 		return 0;
+	}
+
+	int LinuxTextBoxObject::GetSelection(lua_State* L)
+	{
+	    Rtt_LogException("LinuxTextBoxObject:GetSelection() is not implemented\n");
+	    return 0;
 	}
 
 	void LinuxTextBoxObject::dispatch(const char* phase, int pos, ImWchar ch)

--- a/platform/linux/src/Rtt_LinuxTextBoxObject.h
+++ b/platform/linux/src/Rtt_LinuxTextBoxObject.h
@@ -37,6 +37,7 @@ namespace Rtt
 		static int SetTextColor(lua_State *L);
 		static int SetReturnKey(lua_State *L);
 		static int SetSelection(lua_State *L);
+		static int GetSelection(lua_State *L);
 
 	private:
 

--- a/platform/mac/Rtt_MacTextBoxObject.h
+++ b/platform/mac/Rtt_MacTextBoxObject.h
@@ -49,6 +49,7 @@ class MacTextBoxObject : public MacDisplayObject
 		virtual void DidRescaleSimulator( float previousScale, float currentScale );
 		static int setTextColor( lua_State *L );
 		static int setSelection( lua_State *L );
+		static int getSelection( lua_State *L );
 
 	private:
 //		Rect fSelfBounds;

--- a/platform/mac/Rtt_MacTextBoxObject.mm
+++ b/platform/mac/Rtt_MacTextBoxObject.mm
@@ -381,6 +381,27 @@ MacTextBoxObject::setSelection( lua_State *L )
 }
 
 int
+MacTextBoxObject::getSelection(lua_State* L)
+{
+    PlatformDisplayObject *o = (PlatformDisplayObject*)LuaProxy::GetProxyableObject(L, 1);
+    if (&o->ProxyVTable() == &PlatformDisplayObject::GetTextBoxObjectProxyVTable())
+    {
+        NSView *v = ((MacTextBoxObject*)o)->GetView();
+        NSScrollView *scrollview = (NSScrollView*)v;
+        Rtt_NSTextView *t = (Rtt_NSTextView*)[scrollview documentView];
+        NSRange range = t.selectedRange;
+        
+        lua_pushnumber(L, range.location);
+        lua_pushnumber(L, range.location + range.length);
+
+        return 2;
+    }
+    
+    return 0;
+}
+
+
+int
 MacTextBoxObject::ValueForKey( lua_State *L, const char key[] ) const
 {
 	Rtt_ASSERT( key );
@@ -443,6 +464,10 @@ MacTextBoxObject::ValueForKey( lua_State *L, const char key[] ) const
 	else if ( strcmp( "setSelection", key ) == 0 )
 	{
 		lua_pushcfunction( L, setSelection);
+	}
+	else if ( strcmp( "getSelection", key ) == 0 )
+	{
+		lua_pushcfunction( L, getSelection);
 	}
 	else if ( strcmp( "placeholder", key ) == 0 )
 	{

--- a/platform/mac/Rtt_MacTextFieldObject.h
+++ b/platform/mac/Rtt_MacTextFieldObject.h
@@ -54,6 +54,7 @@ class MacTextFieldObject : public MacDisplayObject
 		virtual void DidRescaleSimulator( float previousScale, float currentScale );
 		static int setTextColor( lua_State *L );
 		static int setSelection( lua_State *L );
+		static int getSelection( lua_State *L );
 
 	
 	private:

--- a/platform/windows/Corona.Native.Library.Win32/Interop/UI/TextBox.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Interop/UI/TextBox.cpp
@@ -418,6 +418,26 @@ void TextBox::SetSelection(int startCharacterIndex, int endCharacterIndex)
 	}
 }
 
+bool TextBox::GetSelection(int *outStartCharacterIndex, int *outEndCharacterIndex) const
+{
+	auto windowHandle = GetWindowHandle();
+	if (windowHandle)
+	{
+		DWORD start, end;
+		::SendMessageW(windowHandle, EM_GETSEL, (WPARAM)&start, (LPARAM)&end);
+		if (outStartCharacterIndex)
+		{
+			*outStartCharacterIndex = (int)start;
+		}
+		if (outEndCharacterIndex)
+		{
+			*outEndCharacterIndex = (int)end;
+		}
+		return true;
+	}
+	return false;
+}
+
 void TextBox::SetTextColorToDefault()
 {
 	fIsUsingCustomTextColor = false;

--- a/platform/windows/Corona.Native.Library.Win32/Interop/UI/TextBox.h
+++ b/platform/windows/Corona.Native.Library.Win32/Interop/UI/TextBox.h
@@ -268,6 +268,15 @@ class TextBox : public Control
 		/// </param>
 		void SetSelection(int startCharacterIndex, int endCharacterIndex);
 
+		/// <summary>Gets the text box's current selection start and end character indices.</summary>
+		/// <param name="outStartCharacterIndex">Pointer to an integer that will receive the start index of the selection.</param>
+		/// <param name="outEndCharacterIndex">Pointer to an integer that will receive the end index of the selection.</param>
+		/// <returns>
+		///  <para>Returns true if the indices were successfully fetched.</para>
+		///  <para>Returns false if failed to fetch the indices, in which case the output parameters won't be modified.</para>
+		/// </returns>
+		bool GetSelection(int *outStartCharacterIndex, int *outEndCharacterIndex) const;
+
 		/// <summary>Sets the control's text color to the system default.</summary>
 		void SetTextColorToDefault();
 

--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.cpp
@@ -774,7 +774,7 @@ int WinTextBoxObject::OnGetSelection(lua_State *L)
 	{
 		int startIndex = 0;
 		int endIndex = 0;
-		displayObjectPointer->fTextBoxPointer->GetSelection(startIndex, endIndex);
+		displayObjectPointer->fTextBoxPointer->GetSelection(&startIndex, &endIndex);
 		
 		lua_pushnumber(L, startIndex);
 		lua_pushnumber(L, endIndex);

--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.cpp
@@ -237,6 +237,10 @@ int WinTextBoxObject::ValueForKey(lua_State *L, const char key[]) const
 	{
 		lua_pushcfunction(L, WinTextBoxObject::OnSetSelection);
 	}
+	else if (strcmp("getSelection", key) == 0)
+	{
+		lua_pushcfunction(L, WinTextBoxObject::OnGetSelection);
+	}
 	else if (strcmp("align", key) == 0)
 	{
 		auto alignmentPointer = fTextBoxPointer->GetAlignment();
@@ -759,6 +763,22 @@ int WinTextBoxObject::OnSetSelection(lua_State *L)
 			}
 			displayObjectPointer->fTextBoxPointer->SetSelection(startIndex, endIndex);
 		}
+	}
+	return 0;
+}
+
+int WinTextBoxObject::OnGetSelection(lua_State *L)
+{
+	auto displayObjectPointer = (WinTextBoxObject*)LuaProxy::GetProxyableObject(L, 1);
+	if (&displayObjectPointer->ProxyVTable() == &PlatformDisplayObject::GetTextFieldObjectProxyVTable())
+	{
+		int startIndex = 0;
+		int endIndex = 0;
+		displayObjectPointer->fTextBoxPointer->GetSelection(startIndex, endIndex);
+		
+		lua_pushnumber(L, startIndex);
+		lua_pushnumber(L, endIndex);
+		return 2;
 	}
 	return 0;
 }

--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.h
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinTextBoxObject.h
@@ -114,6 +114,10 @@ class WinTextBoxObject : public WinDisplayObject
 		/// <param name="L">Pointer to the Lua state that invoked this function.</param>
 		static int OnSetSelection(lua_State *L);
 
+		/// <summary>Called by the Lua getSelection() function.</summary>
+		/// <param name="L">Pointer to the Lua state that invoked this function.</param>
+		static int OnGetSelection(lua_State *L);
+
 		/// <summary>Called by the Lua resizeFontToFitHeight() function.</summary>
 		/// <param name="L">Pointer to the Lua state that invoked this function.</param>
 		static int OnResizeFontToFitHeight(lua_State *L);


### PR DESCRIPTION
I was working on a custom pixel art textfield for our game and needed a function that can return the current position of the cursor/selector of a native.textField.
There is a function "setSelection" with which you can set the cursor to a position, but sometimes you just need to know the current position/selection.
So I added the function getSelection below the setSelection function for ios, android, mac and windows.
I've tested all platforms.
I also added support for setSelection for macOs Simulator. There was a Warning before that it's not supported, now it is.

That's how you use it:
`local start, finish = myNativeTextField:getSelection()`
This will return you the cursors/selectors first and last position.

Hope you like it and can add this to a daily build soon, so I can normally use it in our game.
Thanks