### PR TITLE
Android: keep resource as is

### DIFF
--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -5,3 +5,4 @@ org.gradle.jvmargs=-Xmx1280m
 # Migrate To Android X
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableResourceOptimizations=false


### PR DESCRIPTION
> The option setting 'android.enableResourceOptimizations=false' is deprecated. The current default is 'true'. It will be removed in version 8.0 of the Android Gradle plugin.

^ Although the Android Gradle plugin will complain, but afaik Solar2D need to keep the widget resource as-is before found out more practical solution.





