### PR TITLE
fix: json encode not follow keyorder

### DIFF
--- a/platform/resources/dkjson.lua
+++ b/platform/resources/dkjson.lua
@@ -319,7 +319,7 @@ encode2 = function (value, indent, level, buffer, buflen, tables, globalorder, s
         for i = 1, n do
           local k = order[i]
           local v = value[k]
-          if v then
+          if v ~= nil then
             used[k] = true
             buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
             prev = true -- add a seperator before the next element


### PR DESCRIPTION
Fix https://github.com/coronalabs/corona/pull/482, tested with following demo:

```Lua
local json = require("json")
local t = { k1 = 123, k2 = false, k3 = false, k4 = '456' }
local str = json.encode( t, { keyorder = {'k2', 'k1', 'k3', 'k4'} })
print( str )

-- before:  {"k1":123,"k4":"456","k3":false,"k2":false}
-- after:   {"k2":false,"k1":123,"k3":false,"k4":"456"}
```