### PR TITLE
Add property to track deleted/to be deleted display objects

### DIFF
--- a/platform/resources/init.lua
+++ b/platform/resources/init.lua
@@ -554,6 +554,8 @@ display.remove = function( object )
 		local method = object.removeSelf
 		if "function" == type( method ) then
 			method( object ) -- same as object:removeSelf()
+			-- convenience property indicating that the object has been removed or will be removed by next frame
+			object._isRemoved = true
 		end
 	end
 end


### PR DESCRIPTION
Calling `display.remove( object )` or `object:removeSelf()` will not actually delete the display object until the next frame. In some rare instances, this can result in bugs and crashes if the developer attempts to perform certain operations on the objects after they've been removed (via references, for instance).

Some developers are currently checking to see if `object.x` or `object.width` are nil, for instance, to determine if a display object has been removed or not, but these properties only update the next frame after Solar2D has properly disposed of the display objects.

By including this new "private" convenience property, `object._isRemoved = true`, developers would always be able to know if an object has been removed or is about to be removed by next frame. Naturally, this would only affect display objects removed via `display.remove`, but it has long been Solar2D's recommend way of removing display objects.


Code example of the issue:
```lua
local rect = display.newRect( 0, 0, 100, 100 )

display.remove( rect )
print( rect.width ) -- 100

timer.performWithDelay( 1, function()
	print( rect.width ) -- nil
end )
```

This would also apply to widgets, for instance:
```lua
local widget = require( "widget" )

-- Function to handle button events
local function handleButtonEvent( event )
    if ( "ended" == event.phase ) then
        print( "Button was pressed and released" )
    end
end

-- Create the widget
local button1 = widget.newButton(
    {
        left = 100,
        top = 200,
        id = "button1",
        label = "Default",
        onEvent = handleButtonEvent
    }
)

display.remove( button1 )
print( button1._isRemoved ) -- true
```

This single property would remove the guesswork from knowing whether a display object in Solar2D has been removed or not.