### PR TITLE
Core/Android: add sanity check

### DIFF
--- a/librtt/Core/Rtt_Data.h
+++ b/librtt/Core/Rtt_Data.h
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -87,15 +88,13 @@ Data< T >::SetLength( size_t length )
 	{
 		if ( fOwnsStorage )
 			Rtt_FREE( (void *) fStorage );
-		else
-			fOwnsStorage = true;
+
+		// We own this anyway
+		fOwnsStorage = true;
+		fStorage = NULL;
+		fLength = 0;
 		
-		if ( length == 0 )
-		{
-			fStorage = NULL;
-			fLength = 0;
-		}
-		else
+		if ( length != 0 )
 		{
 			fStorage = (T *) Rtt_MALLOC( fAllocator, length * sizeof( T ) );
 
@@ -111,7 +110,8 @@ void
 Data< T >::Set( const T * p, size_t length )
 {
 	SetLength( length );
-	memcpy( (void *) fStorage, p, length * sizeof( T ) );
+	if ( fStorage )
+		memcpy( (void *) fStorage, p, length * sizeof( T ) );
 }
 
 template < typename T >

--- a/librtt/Display/Rtt_LuaLibGraphics.cpp
+++ b/librtt/Display/Rtt_LuaLibGraphics.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -501,6 +502,14 @@ GraphicsLibrary::newOutline( lua_State *L )
 	b2Vec2Vector shape_outline_in_texels;
 
 	const unsigned char *raw_bitmap_buffer = static_cast< const unsigned char * >( platform_bitmap->GetBits( NULL ) );
+
+	if ( ! Rtt_VERIFY( raw_bitmap_buffer ) )
+	{
+		// This is NECESSARY because of the platform_bitmap->GetBits() above.
+		platform_bitmap->FreeBits();
+		Rtt_DELETE(paint);
+		return 0;
+	}
 
 	int alphaIndex;
 	PlatformBitmap::Format format = platform_bitmap->GetFormat();

--- a/platform/android/app/build.gradle.kts
+++ b/platform/android/app/build.gradle.kts
@@ -487,6 +487,8 @@ android.applicationVariants.all {
             }
             delete(metadataConfig)
             val toArchive = outputsList.filter { file(it).name != "config.lu" } + "config.lu"
+            // Make sure it's not appended to an old file
+            delete(compiledLuaArchive)
             mkdir(file(compiledLuaArchive).parent)
             exec {
                 workingDir = file(compiledDir)

--- a/platform/android/ndk/jni/NativeToJavaBridge.cpp
+++ b/platform/android/ndk/jni/NativeToJavaBridge.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -597,8 +598,8 @@ NativeToJavaBridge::GetRawAsset( const char * assetName, Rtt::Data<char> & data 
 						jbyteArrayResult bytesJ( bridge.getEnv(), (jbyteArray) jo );
 						data.Set( (const char *) bytesJ.getValues(), bytesJ.getLength() );
 						bytesJ.release();
-						result = true;
 						bridge.getEnv()->DeleteLocalRef(jo);
+						result = (data.Get() != nullptr);
 					}
 				}
 			}

--- a/platform/android/sdk/src/com/ansca/corona/storage/ZipResourceFile.java
+++ b/platform/android/sdk/src/com/ansca/corona/storage/ZipResourceFile.java
@@ -286,7 +286,9 @@ public class ZipResourceFile {
         ZipEntryRO entry = mHashMap.get(assetPath);
         if (null != entry) {
             if (entry.isUncompressed()) {
-                return entry.getAssetFileDescriptor().createInputStream();
+                AssetFileDescriptor afd = entry.getAssetFileDescriptor();
+                if (null != afd)
+                    return afd.createInputStream();
             } else {
                 ZipFile zf = mZipFiles.get(entry.getZipFile());
                 /** read compressed files **/


### PR DESCRIPTION
> Does it make sense to add these checks in the case of OOM? Should we "fix" these boundary cases? Or should we just expose them to expose the game code error?
> 
> ^These questions bother me, but I'm willing to give it a try, so if the changes don't fit please feel free to discuss.

These fixes come from analyzing the OOM crash stack, enhancing some of the checks.
These changed stack contents in cases where an error had already occurred.

Regarding`Data.Set()`, it is envisioned that in the OOM case, fLength retains a non-zero value even if fStorage is empty. It is good practice to perform a `Data.Get()` check before using it.

Of course, there's also an Android `build.gradle.kts` issue where switching `coronaSrcDir` causes the previous project's `resource.car` content to be incorrectly retained as the gradle script uses the `CoronaBuilder car` command to do the _append_ action.

This time I modified the file header, replaced Corona with Solar2D and added declarations.

Thanks.