### PR TITLE
iOS: Fix for display.save saving black image on iOS 17+

### DIFF
--- a/platform/iphone/Rtt_IPhonePlatformCore.mm
+++ b/platform/iphone/Rtt_IPhonePlatformCore.mm
@@ -146,7 +146,7 @@ IPhonePlatformCore::SaveBitmap( PlatformBitmap* bitmap, NSString* filePath, floa
 
 
 
-	CGBitmapInfo srcBitmapInfo = CGBitmapInfo(kCGBitmapByteOrderDefault);
+	CGBitmapInfo srcBitmapInfo = CGBitmapInfo(kCGImageAlphaNoneSkipLast);
 	CGBitmapInfo dstBitmapInfo = CGBitmapInfo(kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big);
     bool enablePngAlphaSave = false;
     NSString *lowercase = [filePath lowercaseString];


### PR DESCRIPTION
Fix for #654