### PR TITLE
Added check to exact scheduling for notifications

### DIFF
--- a/platform/android/sdk/src/com/ansca/corona/notifications/NotificationServices.java
+++ b/platform/android/sdk/src/com/ansca/corona/notifications/NotificationServices.java
@@ -442,7 +442,14 @@ public final class NotificationServices extends com.ansca.corona.ApplicationCont
 					android.app.AlarmManager alarmManager;
 					String serviceName = android.content.Context.ALARM_SERVICE;
 					alarmManager = (android.app.AlarmManager)context.getSystemService(serviceName);
-					if (android.os.Build.VERSION.SDK_INT >= 23) {
+
+					if (android.os.Build.VERSION.SDK_INT >= 33 && !alarmManager.canScheduleExactAlarms()) {
+						alarmManager.set(
+								android.app.AlarmManager.RTC_WAKEUP,
+								scheduledSettings.getEndTime().getTime(),
+								pendingIntent);
+					}
+					else if (android.os.Build.VERSION.SDK_INT >= 23) {
 						NotificationServices.ApiLevel23.alarmManagerSetExactAndAllowWhileIdle(
 								alarmManager,
 								android.app.AlarmManager.RTC_WAKEUP,


### PR DESCRIPTION
SCHEDULE_EXACT_ALARM, the permission introduced in Android 12 for apps to schedule exact alarms, is no longer being pre-granted to most newly installed apps targeting Android 13 and higher (will be set to denied by default).

And because the SCHEDULE_EXACT_ALARM permission is now denied by default and the permission grant process requires extra steps from users (the user must minimize the application and change the setting), developers are strongly encouraged to evaluate their use cases and determine if exact alarms still make sense for their use cases.

Now for Android devices with SDK greater than or equal to 33, a check has been added for the ability to schedule notifications via AlarmManager.setExactAndAllowWhileIdle(). If this is not possible, then the notification is sent via AlarmManager.set().

For AlarmManager.set() only needs android.permission.POST_NOTIFICATIONS. It can be easily obtained through a modal window using native.showPopup( "requestAppPermission", options )

More information:
https://developer.android.com/about/versions/14/changes/schedule-exact-alarms