### PR TITLE
Fix: Loading an invalid image causes a crash

### DIFF
--- a/librtt/Display/Rtt_TextureFactory.cpp
+++ b/librtt/Display/Rtt_TextureFactory.cpp
@@ -277,7 +277,13 @@ TextureFactory::FindOrCreate(
 	if ( result.IsNull() )
 	{
 		PlatformBitmap *bitmap = CreateBitmap( filePath.GetString(), flags, isMask );
-		result = CreateAndAdd( key, bitmap, true, isRetina );
+
+		if ( bitmap )
+		{
+			result = CreateAndAdd( key, bitmap, true, isRetina );
+		} else {
+			Rtt_ASSERT( result.IsNull() );
+		}
 	}
 
 	return result;

--- a/platform/emscripten/Rtt_EmscriptenBitmap.cpp
+++ b/platform/emscripten/Rtt_EmscriptenBitmap.cpp
@@ -186,6 +186,10 @@ namespace Rtt
 			{
 				fFormat = kRGBA;
 			}
+			else
+			{
+				Rtt_LogException("Failed to load %s\n", path);
+			}
 		}
 		else
 		if (ext == ".png")

--- a/platform/linux/src/Rtt_LinuxBitmap.cpp
+++ b/platform/linux/src/Rtt_LinuxBitmap.cpp
@@ -125,6 +125,10 @@ namespace Rtt
 			{
 				fFormat = kRGBA;
 			}
+			else
+			{
+				Rtt_LogException("Failed to load %s\n", path);
+			}
 		}
 		else if (ext == ".png")
 		{

--- a/platform/shared/Rtt_BitmapUtils.cpp
+++ b/platform/shared/Rtt_BitmapUtils.cpp
@@ -238,6 +238,8 @@ namespace bitmapUtil
 			format = Rtt::PlatformBitmap::Format::kRGBA;
 			return im;
 		}
+
+		return NULL;
 	}
 
 	//


### PR DESCRIPTION
Platform: Linux
Fix the issue when Solar crashes with a segmentation fault on loading an invalid image file (`.png`, `.jpg`, `.bmp`).

### Steps to reproduce:
1. Create an empty file with the extension `.png` (`empty.png`)
2. Put the following line in the new project's `main.lua`
`local background = display.newImageRect("empty.png", 600, 600)`

### Expected behavior:
Runtime Error is reported.

### Actual behavior:
Solar crashed, leaving a log
```
libpng error: Read Error
Segmentation fault
```
