### PR TITLE
Maintenance Action about node and icu4c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: macos-12
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - run: ./tools/GHAction/daily_env.sh
       - name: Set daily build
         run: ./tools/GHAction/process_sources.sh
       - name: Upload Source bundle
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: SourceCode
           path: ./output
@@ -49,7 +49,7 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -60,7 +60,7 @@ jobs:
         env:
           CERT_PASSWORD: ${{ secrets.CertPassword }}
       - name: Upload Corona Native
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Native
           path: ./output
@@ -88,7 +88,7 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -102,7 +102,7 @@ jobs:
       - name: Build templates JSON spec
         run: ./tools/GHAction/generate_xcode_jsons.py
       - name: Upload templates
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Templates-${{ matrix.platform }}-${{ matrix.xcode }}-${{ matrix.target }}
           path: ./output
@@ -133,7 +133,7 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -147,7 +147,7 @@ jobs:
       - name: Build templates JSON spec
         run: ./tools/GHAction/generate_xcode_jsons.py
       - name: Upload templates
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Templates-${{ matrix.platform }}-${{ matrix.xcode }}-${{ matrix.target }}
           path: ./output
@@ -178,7 +178,7 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -192,7 +192,7 @@ jobs:
       - name: Build templates JSON spec
         run: ./tools/GHAction/generate_xcode_jsons.py
       - name: Upload templates
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Templates-${{ matrix.platform }}-${{ matrix.xcode }}-${{ matrix.target }}
           path: ./output
@@ -206,8 +206,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
       - name: Collect templates together
         run: |
           mkdir -p output/iostemplate
@@ -218,7 +218,7 @@ jobs:
       - name: Generate template JSON
         run: find Templates-* -name '*_*-SDKs.json' -exec ./tools/GHAction/aggregate_xcode_jsons.py output {} \+
       - name: Upload templates
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Collected-ios-templates
           path: ./output
@@ -236,7 +236,7 @@ jobs:
           tar -xjf emsdk.tar.xz -C ~/
           xattr -r -d com.apple.quarantine ~/emsdk || true
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -252,7 +252,7 @@ jobs:
           mkdir -p output
           cp -v platform/emscripten/webtemplate.zip output
       - name: Upload webtemplate artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Webtemplate
           path: ./output
@@ -266,15 +266,15 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get Webtemplate
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Webtemplate
       - name: Get Native
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Native
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -282,19 +282,19 @@ jobs:
       - run: ./tools/GHAction/daily_env.sh
       - run: mkdir docs
       - name: Get Sample Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: coronalabs/samples-coronasdk
           path: docs/SampleCode
       - name: Run build script
         run: platform/linux/gh_action.sh
       - name: Upload Linux-Template
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-Template
           path: ./output/linuxtemplate_x64.tgz
       - name: Upload snap
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v4
         with:
           name: Snap
           path: ./output/*.snap
@@ -309,15 +309,15 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get Webtemplate
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Webtemplate
       - name: Get Native
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Native
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -325,7 +325,7 @@ jobs:
       - run: ./tools/GHAction/daily_env.sh
       - run: mkdir docs
       - name: Get Sample Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: coronalabs/samples-coronasdk
           path: docs/SampleCode
@@ -334,7 +334,7 @@ jobs:
         continue-on-error: true
       - run: touch solar2d.flatpak
       - name: Upload flatpak
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v4
         with:
           name: Flatpak
           path: ./solar2d.flatpak
@@ -345,9 +345,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Native
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Native
       - name: Put native in place
@@ -360,7 +360,7 @@ jobs:
           mkdir -p output
           mv CoronaCardsAndroidAAR.zip output/
       - name: Upload Corona Cards Android AAR archive
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: CoronaCards-Android
           path: ./output
@@ -372,7 +372,7 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -386,7 +386,7 @@ jobs:
           mkdir "${WORKSPACE}/output"
           zip -r -y -o "${WORKSPACE}/output"/CoronaCards.framework.zip CoronaCards.framework
       - name: Upload CoronaCards framework archive
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: CoronaCards-iOS
           path: ./output
@@ -398,7 +398,7 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -415,7 +415,7 @@ jobs:
           mkdir "${WORKSPACE}/output"
           zip -r -y -o "${WORKSPACE}/output"/CoronaCards-angle.zip CoronaCards-angle.framework CoronaCards.framework
       - name: Upload CoronaCards framework archive
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: CoronaCards-iOS-angle
           path: ./output
@@ -431,7 +431,7 @@ jobs:
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -440,19 +440,19 @@ jobs:
       - name: Check for macOS min supported version
         run: exit $( echo  $(cat platform/mac/AppDelegate.mm |  perl -ne 'print for /kosVersionCurrent = @"([0-9.]+)"/') ' < '  $(/usr/bin/xcrun --sdk macosx --show-sdk-version)  | bc )
       - name: Get collected templates
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Collected-ios-templates
       - name: Put collected iOS templates in place
         run: cp -Rv Collected-ios-templates/* platform/resources/
       - name: Get Webtemplate
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Webtemplate
       - name: Put webtemplate in place
         run: cp -v Webtemplate/webtemplate.zip platform/resources/
       - name: Get Linux template
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Linux-Template
       - name: Put webtemplate in place
@@ -460,14 +460,14 @@ jobs:
           cp -v Linux-Template/linuxtemplate_x64.tgz platform/resources/
       - run: mkdir docs
       - name: Get Sample Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: coronalabs/samples-coronasdk
           path: docs/SampleCode
       - name: Clean-up docs
         run: rm -rf docs/SampleCode/.git docs/SampleCode/.gitignore
       - name: Get Native
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Native
       - name: Put JRE in place
@@ -480,6 +480,8 @@ jobs:
         run: npm install -g appdmg
       - name: install imagemagick
         run: brew install imagemagick gs || true
+      - name: freshen icu4c for node
+        run: brew upgrade icu4c || brew install icu4c
       - name: Build DMG
         run: ./tools/GHAction/build_dmg.sh
         env:
@@ -497,7 +499,7 @@ jobs:
           APPLE_KEY_ID: ${{ secrets.AppleKeyId }}
           APPLE_ISSUER: ${{ secrets.AppleIssuer }}
       - name: Upload macOS Daily build artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Simulator-macOS
           path: ./output
@@ -536,7 +538,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Get processed code
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: SourceCode
       - name: Unpack source code
@@ -547,7 +549,7 @@ jobs:
         shell: bash
       - run: mkdir -f docs
       - name: Get Sample Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: coronalabs/samples-coronasdk
           path: docs/SampleCode
@@ -557,7 +559,7 @@ jobs:
       - name: Move docs outside the directory
         run: mv docs ../docs
       - name: Get Webtemplate
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Webtemplate
       - name: Put webtemplate in place
@@ -568,7 +570,7 @@ jobs:
         run: |
           curl -sL https://github.com/coronalabs/binary-data/releases/download/1.0/nxtemplate > platform/resources/nxtemplate
       - name: Get Linux template
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Linux-Template
       - name: Put webtemplate in place
@@ -576,7 +578,7 @@ jobs:
           cp -v Linux-Template/linuxtemplate_x64.tgz platform/resources/
         shell: bash
       - name: Get Corona Native
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: Native
       - name: Put native in place
@@ -617,7 +619,7 @@ jobs:
           cp -v ./platform/windows/Bin/Corona.SDK.Installer/Corona.msi output/Corona-$BUILD.msi
         shell: bash
       - name: Upload Widnows Corona artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Simulator-Windows
           path: ./output
@@ -629,7 +631,7 @@ jobs:
       - linux
       - release
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: Snap
       - name: Determine release
@@ -662,7 +664,7 @@ jobs:
       - CoronaCards-iOS-angle
       - native
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./tools/GHAction/daily_env.sh
       - name: Generate Change Log
         run: |
@@ -686,28 +688,28 @@ jobs:
           echo "$GIT_LOG" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
           echo "$GIT_LOG"
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: Simulator-macOS
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: Simulator-Windows
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: CoronaCards-iOS
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: CoronaCards-iOS-angle
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: CoronaCards-Android
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: Native
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: Flatpak
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: Snap
       - run: find Snap -name '*.snap' -execdir mv -v {} s2d.snap \; -quit
@@ -839,7 +841,7 @@ jobs:
     if: (success() || failure()) && !cancelled() && (!contains(github.ref, 'refs/tags/') || github.repository == 'coronalabs/corona')
     steps:
       - uses: technote-space/workflow-conclusion-action@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./tools/GHAction/daily_env.sh
       - name: notify
         run: |


### PR DESCRIPTION
This PR try to fix `node@20` not being updated with the `icu4c` upgrade, on the Solar2D side. Related to https://github.com/coronalabs/corona/pull/680.

# Description

GitHub Action on tag 3705 macOS part failed, the [error](https://github.com/coronalabs/corona/actions/runs/8226561621/job/22495198727#step:21:26146) shows as below, `node@20 (20.11.1)` look for `icu4c 73.2 (libicui18n.73.dylib)` in `74.2` path `/usr/local/Cellar/icu4c/74.2`:

```shell
+ appdmg sdk/dmg/processed_appdmg.json Corona-2024.3705.dmg
dyld[36835]: Library not loaded: /usr/local/opt/icu4c/lib/libicui18n.73.dylib
  Referenced from: <0E183B51-9141-3D2F-B2F4-A5607A6ECA41> /usr/local/Cellar/node@20/20.11.1/bin/node
  Reason: tried: '/usr/local/opt/icu4c/lib/libicui18n.73.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/icu4c/lib/libicui18n.73.dylib' (no such file), '/usr/local/opt/icu4c/lib/libicui18n.73.dylib' (no such file), '/usr/local/lib/libicui18n.73.dylib' (no such file), '/usr/lib/libicui18n.73.dylib' (no such file, not in dyld cache), '/usr/local/Cellar/icu4c/74.2/lib/libicui18n.73.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/Cellar/icu4c/74.2/lib/libicui18n.73.dylib' (no such file), '/usr/local/Cellar/icu4c/74.2/lib/libicui18n.73.dylib' (no such file), '/usr/local/lib/libicui18n.73.dylib' (no such file), '/usr/lib/libicui18n.73.dylib' (no such file, not in dyld cache)
bin/mac/build_dmg.sh: line 269: 36835 Abort trap: 6           appdmg sdk/dmg/processed_appdmg.json "$DMG_FILE"
```

And `icu4c` has been updated when [installing imagemagick](https://github.com/coronalabs/corona/actions/runs/8226561621/job/22495198727#step:20:259):
```shell
==> Fetching dependencies for harfbuzz: libxext and icu4c
```

It seems that `node` has bound the old `icu4c` and has not adapted to the new `icu4c` version, or can we say `node` has not been updated?

# Some clues

1. GitHub Action on tag 3705 [uses](https://github.com/coronalabs/corona/actions/runs/8226561621/job/22495198727#step:1:9) runner image [macOS 13 (20240219.1)](https://github.com/actions/runner-images/pull/9375)  with `node 20.11.1`. The PR was opened on Feb 20.
2. [brew icu4c history](https://github.com/Homebrew/homebrew-core/commits/f1ce66c14daf5e1184efa4111c7a82508c4cb28c/Formula/i/icu4c.rb) indicates `74.2` was updated on Feb 23.
3. [brew node@20 history](https://github.com/Homebrew/homebrew-core/commits/90c02007778049214b6c76120bb74ef702eec449/Formula/n/node%4020.rb) indicates `node@20` also bumped up revision to `20.11.1_1 `with `icu4c 74.2` on Feb 23 too.
4. And https://github.com/Homebrew/homebrew-core/issues/109968 notes that an `icu4c` upgrade should result in `node` also upgrading to a specific revision. 

However, when we use stock `node@20 (20.11.1)` and run `brew install`, `node@20` did not upgrade from `20.11.1` to `20.11.1_1` when `icu4c` was upgraded to `74.2`.

# Possible fix

Not sure where the BUG is, let's adapt it here in Solar2D first.

As early as version 3666, there were 3 commits (545cf9d, 4e65f1a, 0aa8057) related to `icu4c`. I wonder if they can solve this problem? If not, we may have to manually overwrite the installation of the specified node version until the BUG is fixed.

# Bonus

Regarding the actions upgrade mentioned in the [changelog](https://github.blog/changelog/label/actions/), I believe it's time to upgrade the GitHub Actions to the latest version.