### PR TITLE
Android: avoid main thread io and mmap the resource.car

### DIFF
--- a/librtt/Rtt_Archive.cpp
+++ b/librtt/Rtt_Archive.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -31,6 +32,7 @@
 	static const unsigned S_IWUSR = _S_IWRITE;    ///< write by user
 #elif defined( Rtt_ANDROID_ENV )
 	#include "NativeToJavaBridge.h"
+	#include <sys/mman.h>
 #else
 	#include <stdlib.h>
 	#include <unistd.h>
@@ -1009,19 +1011,6 @@ Archive::Archive( Rtt_Allocator& allocator, const char *srcPath )
 		}
 		Rtt_FileClose(filePointer);
 	}
-#elif defined( Rtt_ANDROID_ENV )
-	bool ok = NativeToJavaBridge::GetRawAsset( srcPath, fBits );
-	if ( ok ) {
-		fData = fBits.Get();
-		fDataLen = fBits.Length();
-	}
-#if Rtt_DEBUG_ARCHIVE
-	else
-	{
-		Rtt_TRACE( ( "[Archive::Archive] NativeToJavaBridge::GetRawAsset failed\n", fDataLen ) );
-	}
-#endif
-
 #else
 	int fileDescriptor = Rtt_FileDescriptorOpen(srcPath, O_RDONLY, S_IRUSR);
 	struct stat statbuf;
@@ -1107,7 +1096,7 @@ Archive::Archive( Rtt_Allocator& allocator, const char *srcPath )
 
 Archive::~Archive()
 {
-#if defined( Rtt_ANDROID_ENV ) || defined( Rtt_EMSCRIPTEN_ENV ) || defined( Rtt_NXS_ENV )
+#if defined( Rtt_EMSCRIPTEN_ENV ) || defined( Rtt_NXS_ENV )
 	// Do nothing.
 #elif defined( Rtt_WIN_PHONE_ENV )
 	Rtt_FREE((void*)fData);

--- a/librtt/Rtt_Archive.h
+++ b/librtt/Rtt_Archive.h
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -12,7 +13,7 @@
 
 #if !defined( Rtt_NO_ARCHIVE )
 	#include "Rtt_Lua.h"
-	#if defined( Rtt_ANDROID_ENV ) || defined( Rtt_EMSCRIPTEN_ENV )
+	#if defined( Rtt_EMSCRIPTEN_ENV )
 		#define Rtt_ARCHIVE_COPY_DATA 1
 	#endif
 #endif

--- a/librtt/Rtt_LuaProxyVTable.cpp
+++ b/librtt/Rtt_LuaProxyVTable.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -3759,7 +3760,7 @@ LuaDisplayObjectProxyVTable::PushAndRemove( lua_State *L, GroupObject* parent, S
 		if ( stage )
 		{
 			Rtt_ASSERT( LuaContext::GetRuntime( L )->GetDisplay().HitTestOrphanage() != parent
-						|| LuaContext::GetRuntime( L )->GetDisplay().Orphanage() != parent );
+						&& LuaContext::GetRuntime( L )->GetDisplay().Orphanage() != parent );
 
 			SUMMED_TIMING( par1, "Object: PushAndRemove (release)" );
 

--- a/librtt/Rtt_Runtime.cpp
+++ b/librtt/Rtt_Runtime.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -1208,8 +1209,11 @@ Runtime::LoadApplication( const LoadParameters& parameters )
 
 	// Use kSystemResourceDir b/c resource.car should always live inside the .app bundle
 	String filePath( GetAllocator() );
-	
-    fPlatform.PathForFile( basename, MPlatform::kSystemResourceDir, MPlatform::kDefaultPathFlags, filePath );
+#if defined( Rtt_ANDROID_ENV )
+    fPlatform.PathForFile( basename, MPlatform::kResourceDir, MPlatform::kDefaultPathFlags, filePath );
+#else
+	fPlatform.PathForFile( basename, MPlatform::kSystemResourceDir, MPlatform::kDefaultPathFlags, filePath );
+#endif
 
 	{
 		// Init VM

--- a/platform/android/sdk/src/com/ansca/corona/CoronaActivity.java
+++ b/platform/android/sdk/src/com/ansca/corona/CoronaActivity.java
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -299,8 +300,7 @@ public class CoronaActivity extends Activity {
 		fController.setCoronaSystemApiListener(systemHandler);
 
 		// Attempt to load/reload this application's expansion files, if they exist.
-		com.ansca.corona.storage.FileServices fileServices = new com.ansca.corona.storage.FileServices(this);
-		fileServices.loadExpansionFiles();
+		com.ansca.corona.storage.FileServices.resetAccessedExpansionFileDirectory();
 
 		// Create and set up a store object used to manage in-app purchases.
 		myStore = new com.ansca.corona.purchasing.StoreProxy(fCoronaRuntime, fCoronaRuntime.getController());


### PR DESCRIPTION
This PR removes a main thread IO to avoid ANR; allows Android to use mmap to load Lua code packages; and an additional Rtt_ASSERT correction.

# Remove a main thread IO

There is a risk of ANR when `loadExpansionFiles()` in the main UI thread, so the main UI thread reading is changed to the main thread modifying the state, and the GLThread is used to read.

# Android to use mmap to load Lua code packages

This PR allows Android to load the Lua code package (resource.car) like other platforms, using mmap, to reduce runtime memory by extracting the resource.car at first launch. It doesn't need to be uncompressed every launch, so it also positively affects startup time.

During the public beta phase, it was observed that some models showed the situation where `AssetManager` prematurely returns -1 when decompressing resources (approximately 0.3%). This issue was resolved by improving the accuracy, reliability, and usability of the `extractAssetFile()` method (at least this exception is no longer observed online). The worstcase scenario here is the same as before, when the `getBytesFromFile()` method failed to load the code package into memory all at once, resulting in a black screen after startup, but usually, it will not happen again when restarting the App.

# Rtt_ASSERT correction

Additionally, while debugging other issues, I found an `Rtt_ASSERT` that could not be false. After correcting it to match the context, I guess it's not allowed to move `DisplayObject` from the `Orphanage()` group to the `Orphanage()` group again, that is, to `removeSelf` repeatedly.


Any suggestions are welcome. Thank you.