### PR TITLE
Core: fix newOutline crash when image not found

### DIFF
--- a/librtt/Display/Rtt_LuaLibGraphics.cpp
+++ b/librtt/Display/Rtt_LuaLibGraphics.cpp
@@ -429,6 +429,13 @@ GraphicsLibrary::newOutline( lua_State *L )
 
 		paint = BitmapPaint::NewBitmap( runtime, imageFileName, baseDir, PlatformBitmap::kIsNearestAvailablePixelDensity );
 
+		// eg. Image not found
+		if ( ! Rtt_VERIFY( paint ) )
+		{
+			// Nothing to do.
+			return 0;
+		}
+
 		platform_bitmap = paint->GetBitmap();
 
 		// Crop.


### PR DESCRIPTION
Use the sample project [LiquidFun-ColorGroup](https://github.com/coronalabs/samples-coronasdk/tree/93e6a10650c3379850e63dc008ae3d94c5d29c9b/Physics/LiquidFun-ColorGroup) and make the following modifications, which results Android and macOS Simulator to crash on 3706:

```diff
-72 local image_outline = graphics.newOutline( 1, "outline.png" )
+72 local image_outline = graphics.newOutline( 1, "outline1.png" )
```

This PR avoid [graphics.newOutline()](https://docs.coronalabs.com/api/library/graphics/newOutline.html) crash when image not found, just cause the *object* not to created/display.

