### PR TITLE
Android: fix audio metatable being covered

### DIFF
--- a/platform/android/ndk/Rtt_LuaLibOpenSLES.cpp
+++ b/platform/android/ndk/Rtt_LuaLibOpenSLES.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 // This file is part of the Corona game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -1580,7 +1581,7 @@ namespace Rtt
 		// To provide access to queries via dot-notation (like audio.freeChannels)
 		// I need a metatable on the main audio table.
 		// And that metatable needs to have the __index metamethod defined.
-		luaL_register(L, "metatable.audio", kVTable_m);
+		luaL_register(L, "metatable.audio2", kVTable_m);
 		lua_setmetatable(L, -2);
 
 		lua_pop(L, 1); // pop table


### PR DESCRIPTION
The _metatable_ for Android `audio2` overwrites the _metatable_ for `audio`, causing the following properties (obtained by ___index_) to get incorrectly:

```Lua
audio.freeChannels
audio.unreservedFreeChannels
audio.usedChannels
audio.unreservedUsedChannels
audio.totalChannels
audio.reservedChannels
audio.supportsSessionProperty
```

And an error prints:
```Plain
Unsupported key: supportsSessionProperty in audio library
```

when obtaining the `supportsSessionProperty` instead of return `false`:
```Lua
if supportsSessionProperty == true then
	audio.setSessionProperty(audio.MixMode, audio.AmbientMixMode)
end
```
---

AFAIK, there should be no side effects other than affecting the acquisition of the above properties.
**However, it is still necessary to be cautious about merging, because it is possible to break previous usage, although the previous value is always wrong.**

---

Tested with [Media/AudioPlayer](https://github.com/coronalabs/samples-coronasdk/tree/39cc3bac36621fc316063fcf419b8248bdc5127f/Media/AudioPlayer) and the following new lines:
```Lua
timer.performWithDelay( 1000, function()
    print( "---------------------------------------------------------------------------------------" )
    print( "freeChannels:", audio.freeChannels, audio2.freeChannels )
    print( "totalChannels:", audio.totalChannels, audio2.totalChannels )
    print( "unreservedFreeChannels:", audio.unreservedFreeChannels, audio2.unreservedFreeChannels )
    print( "unreservedUsedChannels:", audio.unreservedUsedChannels, audio2.unreservedUsedChannels )
    print( "usedChannels:", audio.usedChannels, audio2.usedChannels )
    print( "reservedChannels:", audio.reservedChannels, audio2.reservedChannels )
end, 0)
```


Related to:
1. [audio.reserveChannels and audio.reservedChannels don't agree](https://forums.solar2d.com/t/audio-reservechannels-and-audio-reservedchannels-dont-agree/150505)