### PR TITLE
iOS: Fixes to Open Url for iOS 18

### DIFF
--- a/platform/iphone/Rtt_IPhonePlatform.mm
+++ b/platform/iphone/Rtt_IPhonePlatform.mm
@@ -439,7 +439,8 @@ IPhonePlatform::OpenURL( const char* url ) const
 		NSURL* urlPlatform = [NSURL URLWithString:[NSString stringWithUTF8String:url]];
 		if ( [sharedApplication canOpenURL:urlPlatform] )
 		{
-			result = Rtt_VERIFY( [sharedApplication openURL:urlPlatform] );
+			result = Rtt_VERIFY( true ); // We set to true due the fact we don't know if web link opened
+            [[UIApplication sharedApplication] openURL:urlPlatform options:@{} completionHandler:nil];
 		}
 	}
 

--- a/platform/iphone/Rtt_IPhonePlatform.mm
+++ b/platform/iphone/Rtt_IPhonePlatform.mm
@@ -439,7 +439,7 @@ IPhonePlatform::OpenURL( const char* url ) const
 		NSURL* urlPlatform = [NSURL URLWithString:[NSString stringWithUTF8String:url]];
 		if ( [sharedApplication canOpenURL:urlPlatform] )
 		{
-			result = Rtt_VERIFY( true ); // We set to true due the fact we don't know if web link opened
+			result = true; // We set to true due the fact we don't know if web link opened
             [[UIApplication sharedApplication] openURL:urlPlatform options:@{} completionHandler:nil];
 		}
 	}

--- a/platform/iphone/Rtt_IPhonePlatformBase.mm
+++ b/platform/iphone/Rtt_IPhonePlatformBase.mm
@@ -262,7 +262,7 @@ IPhonePlatformBase::OpenURL( const char* url ) const
 		NSURL* urlPlatform = [NSURL URLWithString:[NSString stringWithUTF8String:url]];
 		if ( nil != urlPlatform)
 		{
-            result = true;// We set to true due the fact we don't know if web link opened
+            result = [[UIApplication sharedApplication] canOpenURL:urlPlatform];// Use this to check if the URL can be opened
             [[UIApplication sharedApplication] openURL:urlPlatform options:@{} completionHandler:nil];
 		}
 	}

--- a/platform/iphone/Rtt_IPhonePlatformBase.mm
+++ b/platform/iphone/Rtt_IPhonePlatformBase.mm
@@ -262,7 +262,8 @@ IPhonePlatformBase::OpenURL( const char* url ) const
 		NSURL* urlPlatform = [NSURL URLWithString:[NSString stringWithUTF8String:url]];
 		if ( nil != urlPlatform)
 		{
-			result = [[UIApplication sharedApplication] openURL:urlPlatform];
+            result = true;// We set to true due the fact we don't know if web link opened
+            [[UIApplication sharedApplication] openURL:urlPlatform options:@{} completionHandler:nil];
 		}
 	}
 


### PR DESCRIPTION
" BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO)."

Based on forums
https://forums.solar2d.com/t/on-ios-18-system-openurl-url-does-not-work/356845/2