### PR TITLE
Was missing stdio.h and getting sprintf() errors build web target

### DIFF
--- a/librtt/Renderer/Rtt_FormatExtensionList.cpp
+++ b/librtt/Renderer/Rtt_FormatExtensionList.cpp
@@ -19,6 +19,8 @@
 #include "Corona/CoronaGraphics.h"
 #include <algorithm>
 
+#include <stdio.h>
+
 // ----------------------------------------------------------------------------
 
 namespace Rtt


### PR DESCRIPTION
The build of **experimental** ran into a couple snags.

I tried building the **emscripten** target locally and it ran into the above issue. Not sure if **native**'s issue is related.