### PR TITLE
Native: Fixes To Plugin Downloader for iOS

### DIFF
--- a/tools/CoronaBuilder/BuilderPluginDownloader.lua
+++ b/tools/CoronaBuilder/BuilderPluginDownloader.lua
@@ -154,9 +154,11 @@ local function iOSDownloadPlugins( sdk, platform, build, pluginsToDownload, forc
 			end
 		end
 
-		for _, lib in pairs(plugin.frameworks) do
-			frameworks[lib] = true
-			frameworkSearchPaths[plugin.path] = true
+		if(plugin.frameworks)then
+			for _, lib in pairs(plugin.frameworks) do
+				frameworks[lib] = true
+				frameworkSearchPaths[plugin.path] = true
+			end
 		end
 
 		if(plugin.frameworksOptional)then


### PR DESCRIPTION
Some of my plugins don't need extra Frameworks for Native Build
(i.e my Game Center Plugin)