### PR TITLE
Reset offset correction in "stored on GPU" path

### DIFF
--- a/librtt/Renderer/Rtt_Renderer.cpp
+++ b/librtt/Renderer/Rtt_Renderer.cpp
@@ -632,6 +632,7 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
         fCachedVertexOffset = fVertexOffset;
         fCachedVertexCount = fVertexCount;
         fCachedVertexExtra = fVertexExtra;
+        fOffsetCorrection = 0;
         fVertexExtra = 0;
         fVertexOffset = 0;
         fVertexCount = geometry->GetVerticesUsed();


### PR DESCRIPTION
This one-liner is, I hope, the fix for [this issue](https://forums.solar2d.com/t/release-3713-will-not-build-html5/357035/10).

---

The new stuff in 3713 introduced custom vertex formats. These meant you could no longer always jump right into the geometry data, and thus need a "correction": `fVertexOffset - fOffsetCorrection`, in `Renderer::CheckAndInsertDrawCommand()`.

The "stored on GPU" path would still want essentially the old behavior, since its buffers only have data for themselves, but the correction snippet was still being used, but never zeroing out that value: it's either whatever it last was or (as in the link) some uninitialized garbage. In the latter case that happens to be a negative value and thus produce that WebGL error.

---

This was a general bug&mdash;I believe I _did_ see it in my tests, when indexed meshes were involved (the only source of "stored on GPU" buffers in most builds), but it "went away" (probably when I reordered some objects) and I falsely assumed something had fixed it. The web beta stores all objects on GPU, so the problem couldn't help but show up.