### PR TITLE
Fix for unaligned reads

### DIFF
--- a/librtt/Renderer/Rtt_GLCommandBuffer.cpp
+++ b/librtt/Renderer/Rtt_GLCommandBuffer.cpp
@@ -1405,7 +1405,8 @@ T
 GLCommandBuffer::Read()
 {
     Rtt_ASSERT( fOffset < fBuffer + fBytesAllocated );
-    T result = reinterpret_cast<T*>( fOffset )[0];
+    T result;
+    memcpy( &result, fOffset, sizeof( T ) );
     fOffset += sizeof( T );
     return result;
 }


### PR DESCRIPTION
Versions >= 3713 stream some smaller-than-`int` data to `GLCommandBuffer`: `bool` in the FBO case, and then there are `U16`s elsewhere. _Some_ platforms seem to be choking on the unaligned reads that result.

This is the fix posted in #760. I suspect it's also what #751 is about&mdash;captures and snapshots both touch FBOs&mdash;but still waiting on word there.

This replaces the `reinterpret_cast` + dereference with a (fixed-size, per template instantiation) `memcpy()`. From various C++ discussions I've followed it sounds like all the compilers we use will do the obvious (safe) peephole optimization here.