### PR TITLE
Native: TvOS build.settings support

### DIFF
--- a/bin/mac/CreateInfoPlist.sh
+++ b/bin/mac/CreateInfoPlist.sh
@@ -1,7 +1,28 @@
 #!/bin/bash
 
+PLATFORM=""
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --tvOS)
+            PLATFORM="tvOS"
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 BIN_DIR=$(dirname "$0")
 ASSETS_DIR="$PROJECT_DIR"/../Corona
 
-echo "$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
-"$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
+if [[ -n "$PLATFORM" ]]; then
+    echo "$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/" "$PLATFORM"
+    "$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/" "$PLATFORM"
+else
+    echo "$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
+    "$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
+fi

--- a/bin/mac/buildSettingsToPlist.lua
+++ b/bin/mac/buildSettingsToPlist.lua
@@ -16,7 +16,7 @@ local json = require "json"
 
 local srcAssets = arg[1]
 local appBundleFile = arg[2]
-local deviceType = arg[3] or "iphone"
+local deviceType = arg[3] or "iOS"
 
 local function osExecute(...)
 	print("osExecute: ".. ...)
@@ -44,7 +44,7 @@ local options = {
 	signingIdentity = signingIdentity,
 	sdkRoot = sdkRoot,
 	targetDevice = targetDevice,
-	targetPlatform = "iOS",
+	targetPlatform = deviceType,
 	verbose = verbose,
 	corona_build_id = corona_build_id,
 }

--- a/tools/CoronaBuilder/BuilderPluginDownloader.lua
+++ b/tools/CoronaBuilder/BuilderPluginDownloader.lua
@@ -111,33 +111,42 @@ local function AppleDownloadPlugins( sdk, platform, build, pluginsToDownload, fo
 
 	for _, pluginDir in pairs(pluginDirectories) do
 
-		-- we need to copy .framework files to the resources directory for tvOS
+		-- We need to copy .framework files to the resources directory for tvOS
 		if platform == 'appletvos' or platform == 'appletvsimulator' then
 			local resourcesDir = pluginDir .. '/resources'
 			local frameworkDir = resourcesDir .. '/Frameworks'
-		
+
 			-- Ensure directories exist before copying
 			local function ensureDirectoryExists(path)
 				if lfs.attributes(path, "mode") ~= "directory" then
 					lfs.mkdir(path)
 				end
 			end
-		
+
 			-- Create the necessary directories
 			ensureDirectoryExists(resourcesDir)
 			ensureDirectoryExists(frameworkDir)
-		
+
 			-- Copy all .framework files
 			if lfs.attributes(pluginDir, "mode") == "directory" then
 				for file in lfs.dir(pluginDir) do
 					if file:match("%.framework$") then
 						local src = pluginDir .. '/' .. file
 						local dst = frameworkDir .. '/' .. file
+
+						-- Check if the destination framework already exists
+						if lfs.attributes(dst, "mode") == "directory" then
+							-- Remove the existing framework to prevent nesting
+							os.execute('rm -rf ' .. quoteString(dst))
+						end
+
+						-- Copy the new framework
 						os.execute('cp -r ' .. quoteString(src) .. ' ' .. quoteString(dst))
 					end
 				end
 			end
 		end
+
 		local metadataChunk = loadfile( pluginDir .. '/metadata.lua' )
 		if metadataChunk then
 			local metadata = metadataChunk()


### PR DESCRIPTION
Add option for Native TvOS build support build.settings to plist generation (before was using pulling iOS/iPhone plist settings)

i.e with "$CORONA_ROOT"/Corona/mac/bin/CreateInfoPlist.sh --tvOS
<img width="1058" alt="Screenshot 2025-03-28 at 1 04 30 PM" src="https://github.com/user-attachments/assets/e70fa1a5-9bea-4fd8-a458-0bccd9847d6f" />
