### PR TITLE
Native: MacOS Xcode Building Support

### DIFF
--- a/bin/mac/CreateInfoPlist.sh
+++ b/bin/mac/CreateInfoPlist.sh
@@ -1,7 +1,41 @@
 #!/bin/bash
 
+PLATFORM=""
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --tvOS)
+            PLATFORM="tvOS"
+            ;;
+        --macOS)
+            PLATFORM="OSX"
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+
 BIN_DIR=$(dirname "$0")
 ASSETS_DIR="$PROJECT_DIR"/../Corona
 
-echo "$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
-"$BIN_DIR/lua" "$BIN_DIR"/buildSettingsToPlist.lua "$ASSETS_DIR" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
+if [[ "$PLATFORM" == "OSX" ]]; then
+    STRIPPED_PATH="${EXECUTABLE_FOLDER_PATH//Contents\/MacOS}"
+    DEST_PATH="$BUILT_PRODUCTS_DIR/$STRIPPED_PATH"
+    echo "$BIN_DIR/lua" "$BIN_DIR/buildSettingsToPlist.lua" "$ASSETS_DIR" "$DEST_PATH" "$PLATFORM"
+    "$BIN_DIR/lua" "$BIN_DIR/buildSettingsToPlist.lua" "$ASSETS_DIR" "$DEST_PATH" "$PLATFORM"
+
+elif [[ -n "$PLATFORM" ]]; then
+    DEST_PATH="$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
+    echo "$BIN_DIR/lua" "$BIN_DIR/buildSettingsToPlist.lua" "$ASSETS_DIR" "$DEST_PATH" "$PLATFORM"
+    "$BIN_DIR/lua" "$BIN_DIR/buildSettingsToPlist.lua" "$ASSETS_DIR" "$DEST_PATH" "$PLATFORM"
+
+else
+    DEST_PATH="$BUILT_PRODUCTS_DIR/$EXECUTABLE_FOLDER_PATH/"
+    echo "$BIN_DIR/lua" "$BIN_DIR/buildSettingsToPlist.lua" "$ASSETS_DIR" "$DEST_PATH"
+    "$BIN_DIR/lua" "$BIN_DIR/buildSettingsToPlist.lua" "$ASSETS_DIR" "$DEST_PATH"
+fi

--- a/bin/shared/Compile.lua
+++ b/bin/shared/Compile.lua
@@ -343,6 +343,15 @@ pl_file.delete( CONFIG_META )
 
 -- Create resource.{car,corona-archive} from *.lu
 -- "$BUILDER_PATH" car "$CORONA_TARGET_EXECUTABLE_DIR/resource.corona-archive" "$CORONA_TARGET_EXECUTABLE_DIR"/*.lu
+
+-- If Mac native we need to fix the compile path
+IS_MAC_NATIVE = os.getenv( "IS_MAC_NATIVE" )
+if IS_MAC_NATIVE then 
+	local newPath = string.sub(CORONA_TARGET_EXECUTABLE_DIR, 1, #CORONA_TARGET_EXECUTABLE_DIR - 6) .. '/Resources'
+	os_execute("mv ", CORONA_TARGET_EXECUTABLE_DIR.."/config.lu", newPath, " 2>/dev/null")	
+	CORONA_TARGET_EXECUTABLE_DIR = newPath
+end
+
 print( 'Archiving ' .. CORONA_TARGET_EXECUTABLE_DIR ..'/*.lu into ' .. CORONA_TARGET_EXECUTABLE_DIR .. '/resource' .. RESOURCE_EXT )
 if PLATFORM == "win" then
 	local result = os_execute(

--- a/platform/mac/CoronaBuilder.xcodeproj/project.pbxproj
+++ b/platform/mac/CoronaBuilder.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1012,6 +1012,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A4FCD40A14CF417D0004E91D /* Build configuration list for PBXNativeTarget "CoronaBuilder" */;
 			buildPhases = (
+				DBFB1F202D9DD23C0028F89F /* Override ENV */,
 				A4FCD3E814CF417C0004E91D /* Sources */,
 				A4FCD3E914CF417C0004E91D /* Frameworks */,
 				A4FCD3EA14CF417C0004E91D /* Resources */,
@@ -1234,6 +1235,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DBFB1F202D9DD23C0028F89F /* Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A4FCD3E814CF417C0004E91D /* Sources */ = {
@@ -1507,12 +1531,19 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "../../tools/CoronaBuilder/CoronaBuilder-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.coronalabs.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				USER_HEADER_SEARCH_PATHS = "../../librtt ../../external/lua-5.1.3/src ../../platform/apple";
+				USER_HEADER_SEARCH_PATHS = (
+					../../librtt,
+					"../../external/lua-5.1.3/src",
+					../../platform/apple,
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1540,11 +1571,18 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "../../tools/CoronaBuilder/CoronaBuilder-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.coronalabs.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				USER_HEADER_SEARCH_PATHS = "../../librtt ../../external/lua-5.1.3/src ../../platform/apple";
+				USER_HEADER_SEARCH_PATHS = (
+					../../librtt,
+					"../../external/lua-5.1.3/src",
+					../../platform/apple,
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/platform/mac/CoronaShell/CoronaShell/Base.lproj/MainMenu.xib
+++ b/platform/mac/CoronaShell/CoronaShell/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -297,11 +297,12 @@
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="48" y="-36"/>
         </menu>
-        <window title="CoronaShell" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" showsToolbarButton="NO" frameAutosaveName="CSMainWindow" animationBehavior="default" id="QvC-M9-y7g">
+        <window title="CoronaShell" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="CSMainWindow" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES"/>
             <rect key="contentRect" x="335" y="390" width="320" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1578"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
             <view key="contentView" id="EiT-Mj-1SZ" customClass="CoronaView">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/platform/mac/build_native.sh
+++ b/platform/mac/build_native.sh
@@ -1,0 +1,14 @@
+path=$(cd "$(dirname "$0")" && pwd)
+
+XCODE_LOG_FILTERS="^    export |clang -x |libtool -static |^    cd $CWD"
+FULL_LOG_FILE="mac-build-xcodebuild.log"
+if [ "$WORKSPACE" != "" ]
+then
+    FULL_LOG_FILE="$WORKSPACE/$FULL_LOG_FILE"
+fi
+
+echo "Building CoronaCards For Mac"
+
+    
+xcodebuild SYMROOT="$path/build" -project "${path}"/ratatouille.xcodeproj -target CoronaCards -configuration Release 2>&1 | tee -a "$FULL_LOG_FILE" | egrep -v "$XCODE_LOG_FILTERS"
+checkError

--- a/platform/mac/car.xcodeproj/project.pbxproj
+++ b/platform/mac/car.xcodeproj/project.pbxproj
@@ -213,7 +213,9 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "Developer ID Application: Corona Labs Inc";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /;
 				PRODUCT_NAME = car;

--- a/platform/mac/car.xcodeproj/project.pbxproj
+++ b/platform/mac/car.xcodeproj/project.pbxproj
@@ -213,9 +213,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "Developer ID Application: Corona Labs Inc";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /;
 				PRODUCT_NAME = car;

--- a/platform/mac/lua.xcodeproj/project.pbxproj
+++ b/platform/mac/lua.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -893,6 +893,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C24216D81CCACB6600D8E4BE /* Build configuration list for PBXNativeTarget "libluasocket" */;
 			buildPhases = (
+				DBFB1F302D9DD27F0028F89F /* Override ENV */,
 				C24216D31CCACB6600D8E4BE /* Sources */,
 				C24216D41CCACB6600D8E4BE /* Frameworks */,
 				C24216D51CCACB6600D8E4BE /* Headers */,
@@ -946,6 +947,29 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DBFB1F302D9DD27F0028F89F /* Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		004CEC2B1339724E006ACF35 /* Sources */ = {

--- a/platform/mac/lua.xcodeproj/project.pbxproj
+++ b/platform/mac/lua.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -893,6 +893,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C24216D81CCACB6600D8E4BE /* Build configuration list for PBXNativeTarget "libluasocket" */;
 			buildPhases = (
+				DBFB1E992D9DC70D0028F89F /* Override ENV
+Override ENV */,
 				C24216D31CCACB6600D8E4BE /* Sources */,
 				C24216D41CCACB6600D8E4BE /* Frameworks */,
 				C24216D51CCACB6600D8E4BE /* Headers */,
@@ -946,6 +948,30 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DBFB1E992D9DC70D0028F89F /* Override ENV
+Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV\nOverride ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		004CEC2B1339724E006ACF35 /* Sources */ = {
@@ -1270,8 +1296,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				INSTALL_PATH = /;
 				OTHER_LDFLAGS = "-L$(PROJECT_TEMP_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
@@ -1299,8 +1327,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					LUA_USE_MODERN_MACOSX,

--- a/platform/mac/lua.xcodeproj/project.pbxproj
+++ b/platform/mac/lua.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -893,8 +893,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C24216D81CCACB6600D8E4BE /* Build configuration list for PBXNativeTarget "libluasocket" */;
 			buildPhases = (
-				DBFB1E992D9DC70D0028F89F /* Override ENV
-Override ENV */,
 				C24216D31CCACB6600D8E4BE /* Sources */,
 				C24216D41CCACB6600D8E4BE /* Frameworks */,
 				C24216D51CCACB6600D8E4BE /* Headers */,
@@ -948,30 +946,6 @@ Override ENV */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		DBFB1E992D9DC70D0028F89F /* Override ENV
-Override ENV */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Override ENV\nOverride ENV";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		004CEC2B1339724E006ACF35 /* Sources */ = {
@@ -1296,10 +1270,8 @@ Override ENV */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				INSTALL_PATH = /;
 				OTHER_LDFLAGS = "-L$(PROJECT_TEMP_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
@@ -1327,10 +1299,8 @@ Override ENV */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					LUA_USE_MODERN_MACOSX,

--- a/platform/mac/plugins.xcodeproj/project.pbxproj
+++ b/platform/mac/plugins.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A47B5B7115F9BA95001D60AB /* Build configuration list for PBXNativeTarget "ads" */;
 			buildPhases = (
+				DBFB1F312D9DD9520028F89F /* Override ENV */,
 				A47B5B6415F9BA95001D60AB /* Sources */,
 				A47B5B6515F9BA95001D60AB /* Frameworks */,
 				A47B5B6615F9BA95001D60AB /* Headers */,
@@ -444,6 +445,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A491863D1641DDB800A39286 /* Build configuration list for PBXNativeTarget "analytics" */;
 			buildPhases = (
+				DBFB1F392D9DD9650028F89F /* Override ENV */,
 				A49186341641DDB800A39286 /* Sources */,
 				A49186381641DDB800A39286 /* Frameworks */,
 				A491863A1641DDB800A39286 /* Headers */,
@@ -545,6 +547,49 @@
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DBFB1F312D9DD9520028F89F /* Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DBFB1F392D9DD9650028F89F /* Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A44308A9164C733E00B9117B /* Sources */ = {

--- a/platform/mac/ratatouille.xcodeproj/project.pbxproj
+++ b/platform/mac/ratatouille.xcodeproj/project.pbxproj
@@ -6101,6 +6101,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00B733F612B6F6BB0057F594 /* Build configuration list for PBXNativeTarget "librtt" */;
 			buildPhases = (
+				DBFB1E982D9DC6B60028F89F /* Override ENV */,
 				00B733EF12B6F6740057F594 /* Headers */,
 				00B733F012B6F6740057F594 /* Sources */,
 				00B733F112B6F6740057F594 /* Frameworks */,
@@ -6256,6 +6257,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C229E2031B32221B00D87A7C /* Build configuration list for PBXNativeTarget "librtt-simulator" */;
 			buildPhases = (
+				DBFB1EB22D9DCC220028F89F /* Override ENV */,
 				C229DFDE1B32221B00D87A7C /* Headers */,
 				C229E0AF1B32221B00D87A7C /* Sources */,
 				C229E2001B32221B00D87A7C /* Frameworks */,
@@ -6772,7 +6774,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# FIXME: There must be a better way of doing this\n\n# Copy CoronaCards.framework to a place the CoronaShell build will find it\n\nif [ \"$CONFIGURATION\" == \"Release\" ]\nthen\n    rm -rf \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/CoronaCards.framework\n    mkdir -p \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\n    cp -av \"$TARGET_BUILD_DIR\"/CoronaCards.framework \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\nfi";
+			shellScript = "# FIXME: There must be a better way of doing this\n\n# Copy CoronaCards.framework to a place the CoronaShell build will find it\n\nif [ \"$CONFIGURATION\" == \"Release\" ]\nthen\n    rm -rf \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/CoronaCards.framework\n    mkdir -p \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\n    cp -av \"$TARGET_BUILD_DIR\"/CoronaCards.framework \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\nfi\n";
 		};
 		C2B5FEF11B336C9000DD49E6 /* Run Script (build OSXAppTemplate.zip) */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6817,6 +6819,46 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
 			shellScript = "set -x\nmkdir -p \"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Skins\"\n# Copy all Skins .lua files and the associated .png files, excluding dot files and\n# deleting any that no longer exist in the source directory\nrsync -av --delete --include='*.lua' --include='*.png' --include='*.template' --exclude='.*' --exclude='*' \"$SRCROOT/../resources/Skins/\" \"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Skins/\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DBFB1E982D9DC6B60028F89F /* Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DBFB1EB22D9DCC220028F89F /* Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n\n";
 			showEnvVarsInLog = 0;
 		};
 		F5608E22257AB801000612C1 /* Run Script (copy JRE if exists) */ = {
@@ -8477,11 +8519,13 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -8814,11 +8858,13 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -8873,11 +8919,13 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/platform/mac/ratatouille.xcodeproj/project.pbxproj
+++ b/platform/mac/ratatouille.xcodeproj/project.pbxproj
@@ -6101,6 +6101,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00B733F612B6F6BB0057F594 /* Build configuration list for PBXNativeTarget "librtt" */;
 			buildPhases = (
+				DBFB1F172D9DD1BA0028F89F /* Override ENV */,
 				00B733EF12B6F6740057F594 /* Headers */,
 				00B733F012B6F6740057F594 /* Sources */,
 				00B733F112B6F6740057F594 /* Frameworks */,
@@ -6174,6 +6175,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "rttplayer" */;
 			buildPhases = (
+				DBFB1F1F2D9DD2270028F89F /* Override ENV */,
 				8D1107290486CEB800E47090 /* Resources */,
 				C2427BBA191865E20011CE7A /* CopyFiles */,
 				8D11072C0486CEB800E47090 /* Sources */,
@@ -6256,6 +6258,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C229E2031B32221B00D87A7C /* Build configuration list for PBXNativeTarget "librtt-simulator" */;
 			buildPhases = (
+				DBFB1F1E2D9DD1CC0028F89F /* Override ENV */,
 				C229DFDE1B32221B00D87A7C /* Headers */,
 				C229E0AF1B32221B00D87A7C /* Sources */,
 				C229E2001B32221B00D87A7C /* Frameworks */,
@@ -6819,7 +6822,7 @@
 			shellScript = "set -x\nmkdir -p \"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Skins\"\n# Copy all Skins .lua files and the associated .png files, excluding dot files and\n# deleting any that no longer exist in the source directory\nrsync -av --delete --include='*.lua' --include='*.png' --include='*.template' --exclude='.*' --exclude='*' \"$SRCROOT/../resources/Skins/\" \"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Skins/\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DBFB1E982D9DC6B60028F89F /* Override ENV */ = {
+		DBFB1F172D9DD1BA0028F89F /* Override ENV */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -6839,7 +6842,7 @@
 			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DBFB1EB22D9DCC220028F89F /* Override ENV */ = {
+		DBFB1F1E2D9DD1CC0028F89F /* Override ENV */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -6856,8 +6859,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n\n";
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		DBFB1F1F2D9DD2270028F89F /* Override ENV */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Override ENV";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export CURRENT_ARCH=\"${ARCHS}\"\n";
 		};
 		F5608E22257AB801000612C1 /* Run Script (copy JRE if exists) */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/platform/mac/ratatouille.xcodeproj/project.pbxproj
+++ b/platform/mac/ratatouille.xcodeproj/project.pbxproj
@@ -8538,11 +8538,13 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -8875,11 +8877,13 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -8934,11 +8938,13 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/platform/mac/ratatouille.xcodeproj/project.pbxproj
+++ b/platform/mac/ratatouille.xcodeproj/project.pbxproj
@@ -6101,7 +6101,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00B733F612B6F6BB0057F594 /* Build configuration list for PBXNativeTarget "librtt" */;
 			buildPhases = (
-				DBFB1E982D9DC6B60028F89F /* Override ENV */,
 				00B733EF12B6F6740057F594 /* Headers */,
 				00B733F012B6F6740057F594 /* Sources */,
 				00B733F112B6F6740057F594 /* Frameworks */,
@@ -6257,7 +6256,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C229E2031B32221B00D87A7C /* Build configuration list for PBXNativeTarget "librtt-simulator" */;
 			buildPhases = (
-				DBFB1EB22D9DCC220028F89F /* Override ENV */,
 				C229DFDE1B32221B00D87A7C /* Headers */,
 				C229E0AF1B32221B00D87A7C /* Sources */,
 				C229E2001B32221B00D87A7C /* Frameworks */,
@@ -6774,7 +6772,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# FIXME: There must be a better way of doing this\n\n# Copy CoronaCards.framework to a place the CoronaShell build will find it\n\nif [ \"$CONFIGURATION\" == \"Release\" ]\nthen\n    rm -rf \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/CoronaCards.framework\n    mkdir -p \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\n    cp -av \"$TARGET_BUILD_DIR\"/CoronaCards.framework \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\nfi\n";
+			shellScript = "# FIXME: There must be a better way of doing this\n\n# Copy CoronaCards.framework to a place the CoronaShell build will find it\n\nif [ \"$CONFIGURATION\" == \"Release\" ]\nthen\n    rm -rf \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/CoronaCards.framework\n    mkdir -p \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\n    cp -av \"$TARGET_BUILD_DIR\"/CoronaCards.framework \"$TARGET_BUILD_DIR\"/../../CoronaShell/build/Release/\nfi";
 		};
 		C2B5FEF11B336C9000DD49E6 /* Run Script (build OSXAppTemplate.zip) */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -8519,13 +8517,11 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -8858,13 +8854,11 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -8919,13 +8913,11 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = CoronaSimulator.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_RESOURCE_RULES_PATH = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BG2J43EA88;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = A6QFRGXX8S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/platform/resources/CoronaPListSupport.lua
+++ b/platform/resources/CoronaPListSupport.lua
@@ -152,7 +152,7 @@ function CoronaPListSupport.modifyPlist( options )
 	end
 
     print("Creating Info.plist...")
-
+	print(options.appBundleFile)
 	-- Convert the Info.plist to JSON and read it in
 	os.execute( "plutil -convert json -o '"..tmpJSONFile.."' "..infoPlistFile)
 
@@ -425,7 +425,9 @@ function CoronaPListSupport.modifyPlist( options )
 		if settings then
 			-- add'l custom plist settings specific to OS X
 			local buildSettingsPlist = settings.osx and settings.osx.plist
-
+			if(settings.macos) then 
+				buildSettingsPlist = settings.macos.plist
+			end
 			if buildSettingsPlist then
 				--print("Adding custom plist settings: ".. json.encode(buildSettingsPlist))
 				--print("buildSettingsPlist: "..json.encode(buildSettingsPlist))


### PR DESCRIPTION
I have been building been working with a client to do Solar2D Mac App building from Xcode, I still need to post a template to support this, but I basically put a copy of CoronaCards for Mac in native folder(under Mac) and tweak the lua output from the compiler path for Native Mac Building.


This also includes support to build MacOS Sim on Apple Silicon natively and locally