### PR TITLE
Made some headers C-friendly

### DIFF
--- a/librtt/Corona/CoronaGraphics.h
+++ b/librtt/Corona/CoronaGraphics.h
@@ -206,7 +206,7 @@ typedef void (*CoronaStateBlockDirty)( const CoronaCommandBuffer * commandBuffer
 /**
  This structure describes a state block.
 */
-struct CoronaStateBlock {
+typedef struct CoronaStateBlock {
     /**
      Required
      Size of block, in bytes.
@@ -242,7 +242,7 @@ struct CoronaStateBlock {
      TODO: used e.g. in Vulkan
     */
     int dontHash;
-};
+} CoronaStateBlock;
 
 /**
  Permanently register a state block.

--- a/librtt/Corona/CoronaObjects.h
+++ b/librtt/Corona/CoronaObjects.h
@@ -536,7 +536,7 @@ typedef struct CoronaObjectParams {
      If non-0, the method parameter chain is represented by `ref`; else `head`.
     */
     int useRef;
-} CoronaObjectsParams;
+} CoronaObjectParams;
 
 // ----------------------------------------------------------------------------
 

--- a/librtt/Corona/CoronaPublicTypes.h
+++ b/librtt/Corona/CoronaPublicTypes.h
@@ -11,7 +11,7 @@
 #ifndef _CoronaPublicTypes_H__
 #define _CoronaPublicTypes_H__
 
-#define CORONA_DECLARE_PUBLIC_TYPE( TYPE ) struct Corona##TYPE
+#define CORONA_DECLARE_PUBLIC_TYPE( TYPE ) typedef struct Corona##TYPE Corona##TYPE
 
 CORONA_DECLARE_PUBLIC_TYPE( Any );
 CORONA_DECLARE_PUBLIC_TYPE( Renderer );


### PR DESCRIPTION
@kan6868 and I have been working on a [Tiny C compiler](https://www.bellard.org/tcc/) plugin.

To be useful, it's hooked up to Solar's "Corona" and "lua" headers.

This being a _C_ compiler, it got tripped up by a few C++-isms I let slip into previous PRs. These pretty much all involve little `typedef` goofs.

With these edits the plugin works well. (At the moment the plugin points to copies of the headers with these same fixes.)