### PR TITLE
Html5: onComplete event fixes

### DIFF
--- a/platform/emscripten/Rtt_PlatformWebAudioPlayer.cpp
+++ b/platform/emscripten/Rtt_PlatformWebAudioPlayer.cpp
@@ -38,9 +38,9 @@ namespace Rtt
 extern "C"
 {
 	// Java ==> C callback
-	void EMSCRIPTEN_KEEPALIVE jsOnSoundEnded(int channel, PlatformSDLmixerPlaybackFinishedCallback *notifier)
+	void EMSCRIPTEN_KEEPALIVE jsOnSoundEnded(int channel, PlatformSDLmixerPlaybackFinishedCallback *notifier, bool finished_naturally)
 	{
-		sdlAudio.NotificationCallback(channel, notifier);
+		sdlAudio.NotificationCallback(channel, notifier, finished_naturally);
 	}
 
 	// JS API
@@ -435,7 +435,7 @@ extern "C"
 		return jsAudioGetMasterVolume();
 	}
 
-	void PlatformWebAudioPlayer::NotificationCallback(int which_channel, PlatformSDLmixerPlaybackFinishedCallback *notifier)
+	void PlatformWebAudioPlayer::NotificationCallback(int which_channel, PlatformSDLmixerPlaybackFinishedCallback *notifier, bool finished_naturally)
 	{
 		if (notifier)
 		{
@@ -453,7 +453,7 @@ extern "C"
 
 					// Bug 5724: In addition to setting all the callback properties, we pass the notifier in to transfer ownership.
 					// We expect when the event is fired and deleted, it will also delete the notifier with it.
-					e->SetProperties(which_channel, 0, 0, 0, notifier);
+					e->SetProperties(which_channel, 0, 0, finished_naturally ? 1 : 0, notifier);
 					notifier->ScheduleDispatch(e);
 				}
 			}

--- a/platform/emscripten/Rtt_PlatformWebAudioPlayer.h
+++ b/platform/emscripten/Rtt_PlatformWebAudioPlayer.h
@@ -152,7 +152,7 @@ namespace Rtt
 		void BeginInterruption();
 		void EndInterruption();
 		bool IsInInterruption() const;
-		void NotificationCallback(int which_channel, PlatformSDLmixerPlaybackFinishedCallback *notifier);
+		void NotificationCallback(int which_channel, PlatformSDLmixerPlaybackFinishedCallback *notifier, bool finished_naturally);
 		void RuntimeWillTerminate(const Runtime& sender);
 		
 		void setProperty(int ch, const char* key, float val);

--- a/platform/emscripten/Rtt_PlatformWebAudioPlayer.js
+++ b/platform/emscripten/Rtt_PlatformWebAudioPlayer.js
@@ -80,11 +80,12 @@ var audioLibrary =
 
 			this.fSource.onended = function () {
 				var ch = this.parent;
-				//console.log('channel finished', ch);
+				console.log('channel finished', ch);
+				console.log(ch.fLuaCallback);
 
 				ch.fStartedAt = 0;
 				if (ch.fLoops == 0) {
-					_jsOnSoundEnded(ch.fChannel, ch.fLuaCallback);
+					_jsOnSoundEnded(ch.fChannel, ch.fLuaCallback, true);
 
 					// free channel
 					ch.clear();


### PR DESCRIPTION
event.completed always returns false on html5

```
local sound = audio.loadSound("soundfile.mp3")  -- Use your actual file name

-- Define the onComplete listener
local function onAudioComplete(event)
   if event.completed then
       print("This never runs on html")
   end
end

-- Play the audio with an onComplete listener
audio.play(sound, { onComplete = onAudioComplete })
```