### PR TITLE
[Linux] Fix bad behavior when changing skin

### DIFF
--- a/platform/linux/src/Rtt_LinuxSimulator.cpp
+++ b/platform/linux/src/Rtt_LinuxSimulator.cpp
@@ -408,12 +408,19 @@ namespace Rtt
 
 			int w = skin->screenWidth;
 			int h = skin->screenHeight;
+			
+			if (orientation == DeviceOrientation::kSidewaysRight || orientation == DeviceOrientation::kSidewaysLeft)
+			{
+				std::swap(w, h);
+			}
+			
 			while (w > screen.w || h > screen.h)
 			{
 				w /= skinScaleFactor;
 				h /= skinScaleFactor;
 			}
 			fContext->SetSize(w, h);
+			fContext->RestartRenderer();
 		}
 	}
 

--- a/platform/linux/src/Rtt_LinuxSimulator.cpp
+++ b/platform/linux/src/Rtt_LinuxSimulator.cpp
@@ -337,6 +337,7 @@ namespace Rtt
 		{
 			const SkinProperties* skin = (const SkinProperties*)e.user.data1;
 			OnViewAsChanged(skin);
+			PushEvent(sdl::onCloseDialog);
 			break;
 		}
 


### PR DESCRIPTION
- Skin selection dialog does not close after selecting another skin.
- Orientation is not correct when selecting skin (default is always portrait).