### PR TITLE
[HTML5] Enable Vsync, optimize CSS for mobile.

### DIFF
--- a/platform/emscripten/Rtt_EmscriptenContext.cpp
+++ b/platform/emscripten/Rtt_EmscriptenContext.cpp
@@ -511,13 +511,13 @@ namespace Rtt
 			//Rtt_LogException("Unsupported orientation: '%s'", orientation.c_str());
 		}
 
-		jsContextInit((int)fWidth, (int)fHeight, fOrientation);
+
 		#if defined(EMSCRIPTEN)
 		
 			devicePixelRatio = emscripten_get_device_pixel_ratio();
 
 		#endif
-
+		jsContextInit((int)(fWidth * devicePixelRatio), (int)(fHeight * devicePixelRatio), fOrientation);
 		//Scale double
 		float scaleX = (float)(((float)jsWindowWidth * devicePixelRatio) / fWidth);
 		float scaleY = (float)(((float)jsWindowHeight * devicePixelRatio) / fHeight);

--- a/platform/emscripten/Rtt_EmscriptenContext.cpp
+++ b/platform/emscripten/Rtt_EmscriptenContext.cpp
@@ -531,6 +531,7 @@ namespace Rtt
 		flags |= SDL_WINDOW_RESIZABLE;
 		fWindow = SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, (int)scaledWidth, (int)scaledHeight, flags);
 		SDL_GL_CreateContext(fWindow);
+		SDL_GL_SetSwapInterval(1); // Enable vsync
 		fPlatform->setWindow(fWindow, fOrientation);
 
 #if defined(EMSCRIPTEN)

--- a/platform/emscripten/gmake/build_app.sh
+++ b/platform/emscripten/gmake/build_app.sh
@@ -99,8 +99,8 @@ pushd $path > /dev/null
 	echo " "
 	echo "Building Corona libraries:"
 
-	echo '\t' make AR=emar CC=emcc CXX=em++ verbose=1 config="$CONFIG" CXXFLAGS="-s LEGACY_VM_SUPPORT=1 -s USE_SDL=2"
-	make AR=emar CC=emcc CXX=em++ verbose=1 config="$CONFIG" CXXFLAGS="-s LEGACY_VM_SUPPORT=1 -s USE_SDL=2 -I\"$path/hack_includes\""
+	echo '\t' make AR=emar CC=emcc CXX=em++ verbose=1 config="$CONFIG" CXXFLAGS="-s USE_SDL=2"
+	make AR=emar CC=emcc CXX=em++ verbose=1 config="$CONFIG" CXXFLAGS="-s USE_SDL=2 -I\"$path/hack_includes\""
 	checkError
 
 	echo " "
@@ -124,8 +124,8 @@ pushd $path > /dev/null
 
 	echo " "
 	echo "Building HTML:"
-	echo '\t' emcc obj/"$CONFIG"/libratatouille.a obj/"$CONFIG"/librtt.a $CC_FLAGS obj/"$CONFIG"/libBox2D.a $CC_FLAGS obj/"$CONFIG"/liblua.a $CC_FLAGS obj/"$CONFIG"/libpng.a $CC_FLAGS obj/"$CONFIG"/libjpeg.a $CC_FLAGS obj/"$CONFIG"/libz.a $CC_FLAGS obj/"$CONFIG"/liblfs.a $CC_FLAGS obj/"$CONFIG"/liblpeg.a $CC_FLAGS obj/"$CONFIG"/libRenderer.a -s LEGACY_VM_SUPPORT=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -O3 -s USE_SDL=2 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=128MB --js-library ../Rtt_PlatformWebAudioPlayer.js --js-library ../Rtt_EmscriptenPlatform.js --js-library ../Rtt_EmscriptenVideo.js --preload-file "$TMP_DIR"@/ -o "$OUTPUT_HTML"
-	emcc obj/"$CONFIG"/libratatouille.a obj/"$CONFIG"/librtt.a $CC_FLAGS obj/"$CONFIG"/libBox2D.a $CC_FLAGS obj/"$CONFIG"/liblua.a $CC_FLAGS obj/"$CONFIG"/libpng.a $CC_FLAGS obj/"$CONFIG"/libjpeg.a $CC_FLAGS obj/"$CONFIG"/libz.a $CC_FLAGS obj/"$CONFIG"/liblfs.a $CC_FLAGS obj/"$CONFIG"/liblpeg.a $CC_FLAGS obj/"$CONFIG"/libRenderer.a -s LEGACY_VM_SUPPORT=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -O3 -s USE_SDL=2 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=128MB --js-library ../Rtt_PlatformWebAudioPlayer.js --js-library ../Rtt_EmscriptenPlatform.js --js-library ../Rtt_EmscriptenVideo.js -lidbfs.js --preload-file "$TMP_DIR"@/ -o "$OUTPUT_HTML"
+	echo '\t' emcc obj/"$CONFIG"/libratatouille.a obj/"$CONFIG"/librtt.a $CC_FLAGS obj/"$CONFIG"/libBox2D.a $CC_FLAGS obj/"$CONFIG"/liblua.a $CC_FLAGS obj/"$CONFIG"/libpng.a $CC_FLAGS obj/"$CONFIG"/libjpeg.a $CC_FLAGS obj/"$CONFIG"/libz.a $CC_FLAGS obj/"$CONFIG"/liblfs.a $CC_FLAGS obj/"$CONFIG"/liblpeg.a $CC_FLAGS obj/"$CONFIG"/libRenderer.a -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -O3 -s USE_SDL=2 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=128MB --js-library ../Rtt_PlatformWebAudioPlayer.js --js-library ../Rtt_EmscriptenPlatform.js --js-library ../Rtt_EmscriptenVideo.js --preload-file "$TMP_DIR"@/ -o "$OUTPUT_HTML"
+	emcc obj/"$CONFIG"/libratatouille.a obj/"$CONFIG"/librtt.a $CC_FLAGS obj/"$CONFIG"/libBox2D.a $CC_FLAGS obj/"$CONFIG"/liblua.a $CC_FLAGS obj/"$CONFIG"/libpng.a $CC_FLAGS obj/"$CONFIG"/libjpeg.a $CC_FLAGS obj/"$CONFIG"/libz.a $CC_FLAGS obj/"$CONFIG"/liblfs.a $CC_FLAGS obj/"$CONFIG"/liblpeg.a $CC_FLAGS obj/"$CONFIG"/libRenderer.a -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -O3 -s USE_SDL=2 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=128MB --js-library ../Rtt_PlatformWebAudioPlayer.js --js-library ../Rtt_EmscriptenPlatform.js --js-library ../Rtt_EmscriptenVideo.js -lidbfs.js --preload-file "$TMP_DIR"@/ -o "$OUTPUT_HTML"
 	checkError
 
 

--- a/platform/emscripten/gmake/template.webapp/emscripten-nosplash.html
+++ b/platform/emscripten/gmake/template.webapp/emscripten-nosplash.html
@@ -7,6 +7,14 @@
         <style>
             body {
               background-color: black;
+              margin: 0; 
+              padding: 0;
+              box-sizing: border-box;
+              width: 100%;
+              height: 100%;
+              height: 100dvh; /* Dynamic viewport that excludes browser UI bars */
+              overflow: hidden;
+              position: fixed; /* Prevents scrolling on mobile */
             }
             body > div {
                 position: absolute;
@@ -28,6 +36,32 @@
                 box-shadow: 0 2px 3px rgba(0,0,0,.5) inset;
                 width: 50%;
                 height: 8px
+            }
+            /* Support for mobile devices */
+            @media screen and (max-width: 768px) {
+              body > div {
+                width: 100vw;
+                height: 100vh;
+                height: 100dvh; /* Dynamic height excluding browser UI bars */
+                min-height: -webkit-fill-available; /* Safari on iOS */
+                min-height: stretch; /* Generic fallback */
+              }
+
+              html, body {
+                min-height: -webkit-fill-available; /* Safari on iOS */
+                min-height: stretch; /* Generic fallback */
+              }
+            }
+
+            /* Specific support for iOS Safari */
+            @supports (-webkit-touch-callout: none) {
+              body > div {
+                height: -webkit-fill-available;
+              }
+
+              html, body {
+                height: -webkit-fill-available;
+              }
             }
         </style>
     </head>

--- a/platform/emscripten/gmake/template.webapp/emscripten.html
+++ b/platform/emscripten/gmake/template.webapp/emscripten.html
@@ -7,6 +7,14 @@
         <style>
             body {
               background-color: black;
+              margin: 0; 
+              padding: 0;
+              box-sizing: border-box;
+              width: 100%;
+              height: 100%;
+              height: 100dvh; /* Dynamic viewport that excludes browser UI bars */
+              overflow: hidden;
+              position: fixed; /* Prevents scrolling on mobile */
             }
             body > div {
                 position: absolute;
@@ -28,6 +36,32 @@
                 box-shadow: 0 2px 3px rgba(0,0,0,.5) inset;
                 width: 50%;
                 height: 8px
+            }
+            /* Support for mobile devices */
+            @media screen and (max-width: 768px) {
+              body > div {
+                width: 100vw;
+                height: 100vh;
+                height: 100dvh; /* Dynamic height excluding browser UI bars */
+                min-height: -webkit-fill-available; /* Safari on iOS */
+                min-height: stretch; /* Generic fallback */
+              }
+
+              html, body {
+                min-height: -webkit-fill-available; /* Safari on iOS */
+                min-height: stretch; /* Generic fallback */
+              }
+            }
+
+            /* Specific support for iOS Safari */
+            @supports (-webkit-touch-callout: none) {
+              body > div {
+                height: -webkit-fill-available;
+              }
+
+              html, body {
+                height: -webkit-fill-available;
+              }
             }
         </style>
     </head>


### PR DESCRIPTION
- Some improvements to make the build work well on mobile.
- Remove LEGACY_VM_SUPPORT Because it is no longer needed.
- Enable Vsync.
- Scale the init config value with devicePixelRatio.

[Alecgames](<https://www.alecgames.com/>) has had some good games built on this PR, here is an example.
It works well on both PC and Mobile.

https://effulgent-malasada-e96974.netlify.app/

Test with this [webtemplate.zip](https://github.com/user-attachments/files/21085154/webtemplate.zip)
