### PR TITLE
[HTML5] LetterBox portrait fullscreen supported, add web build settings.

### DIFF
--- a/platform/emscripten/Rtt_EmscriptenContext.cpp
+++ b/platform/emscripten/Rtt_EmscriptenContext.cpp
@@ -1001,6 +1001,12 @@ namespace Rtt
 							w = fWidth * scaleX;
 							h = fHeight * scaleY;
 						}
+						else if (stricmp(fRuntimeDelegate->fScaleMode.c_str(), "letterBox") == 0)
+						{
+							//Scale to fullscreen
+							w = fWidth * scaleX;
+							h = fHeight * scaleY;
+						}
 						else
 						{
 							w = fWidth * scale;

--- a/platform/emscripten/Rtt_EmscriptenContext.cpp
+++ b/platform/emscripten/Rtt_EmscriptenContext.cpp
@@ -570,12 +570,7 @@ namespace Rtt
 
 		// hack
 #ifdef EMSCRIPTEN
-		if ((stricmp(fRuntimeDelegate->fScaleMode.c_str(), "zoomStretch") == 0) || (stricmp(fRuntimeDelegate->fScaleMode.c_str(), "zoomEven") == 0))
-		{
-			EM_ASM_INT({	window.dispatchEvent(new Event('resize')); });
-		}
-
-		emscripten_set_element_css_size("canvas", (int)(scaledWidth / devicePixelRatio), (int)(scaledHeight / devicePixelRatio));
+		EM_ASM_INT({	window.dispatchEvent(new Event('resize')); });
 #endif
 
 		return true;

--- a/platform/resources/valid_build_settings.lua
+++ b/platform/resources/valid_build_settings.lua
@@ -320,7 +320,16 @@ settings =
 		preferenceStorage = "",
 		singleInstance = true,
 	},
-
+	web =
+	{
+		defaultMode = "",
+		defaultViewWidth = 1,
+		defaultViewHeight = 1,
+		titleText =
+		{
+			default = "",
+		},
+	},
 	window =
 	{
 		defaultMode = "",


### PR DESCRIPTION
- Scaling mode letterBox and portrait orientation now can expand to fullscreen with defaultMode = "fullscreen".
- Add web buildsettings to separate web from window settings.
```lua
--build.settings

web = {
		defaultMode = "fullscreen",
		defaultViewWidth = 1920,
		defaultViewHeight = 1080,
		titleText = 
		{
		   default = "Window Title Test",
		}
	},
```