### PR TITLE
Core/Physics: Add option needHull to Outline/Shape body to using Hull Builder.

### DIFF
--- a/external/b2Separator-cpp/b2Separator.cpp
+++ b/external/b2Separator-cpp/b2Separator.cpp
@@ -36,7 +36,9 @@ bool b2Separator::SeparateAndCreateFixtures( b2Body *body,
 												FixtureCreator_t fixture_creator,
 												b2Vec2Vector &vertices_vec,
 												b2Vec2 &translate,
-												b2Vec2 &scale )
+												b2Vec2 &scale,
+                                                bool needHull
+                                            )
 {
 	bool vertices_added = false;
 
@@ -97,7 +99,7 @@ bool b2Separator::SeparateAndCreateFixtures( b2Body *body,
 				DEBUG_PRINT( "*** Fixture %03d : Vertex %03d : x, y: %f, %f\n", i, j, v.x, v.y );
 	        }
 
-	        bool ok = polyShape.Set( &( vertices[ 0 ] ), (int)m );
+	        bool ok = polyShape.Set( &( vertices[ 0 ] ), (int)m, needHull);
 			if( ! ok )
 			{
 				// Set() failed. Skip this polygon.

--- a/external/b2Separator-cpp/b2Separator.h
+++ b/external/b2Separator-cpp/b2Separator.h
@@ -46,7 +46,7 @@ public:
 									FixtureCreator_t fixture_creator,
 									b2Vec2Vector &vertices_vec,
 									b2Vec2 &translate,
-									b2Vec2 &scale );
+									b2Vec2 &scale, bool needHull);
 
 		/**
 		 * Checks whether the vertices in <code>verticesVec</code> can be properly distributed into the new fixtures (more specifically, it makes sure there are no overlapping segments and the vertices are in clockwise order).

--- a/librtt/Rtt_LuaLibPhysics.cpp
+++ b/librtt/Rtt_LuaLibPhysics.cpp
@@ -2105,6 +2105,11 @@ InitializeFixtureUsing_Shape( lua_State *L,
 								b2Body *body,
 								float meter_per_pixels_scale )
 {
+	lua_getfield(L, lua_arg_index, "needHull");
+	bool needHull = (lua_isboolean(L, -1) &&
+		lua_toboolean(L, -1));
+	lua_pop(L, 1);
+
 	lua_getfield( L, lua_arg_index, "shape" );
 	if ( lua_istable( L, -1 ) )
 	{
@@ -2134,7 +2139,7 @@ InitializeFixtureUsing_Shape( lua_State *L,
 		b2PolygonShape polygonDef;
 
 		bool ok = polygonDef.Set( &vertexList[ 0 ],
-									(int)vertexList.size() );
+									(int)vertexList.size(), needHull);
 		if( ok )
 		{
 			InitializeFixtureFromLua( L,

--- a/librtt/Rtt_LuaLibPhysics.cpp
+++ b/librtt/Rtt_LuaLibPhysics.cpp
@@ -1752,6 +1752,12 @@ InitializeFixtureUsing_Outline( lua_State *L,
 								b2Body *body,
 								float meter_per_pixels_scale )
 {
+
+	lua_getfield(L, lua_arg_index, "needHull");
+	bool needHull = (lua_isboolean(L, -1) &&
+		lua_toboolean(L, -1));
+	lua_pop(L, 1);
+
 	lua_getfield( L, lua_arg_index, "outline" );
 	if( lua_istable( L, -1 ) )
 	{
@@ -1870,7 +1876,7 @@ InitializeFixtureUsing_Outline( lua_State *L,
 													_FixtureCreator,
 													vertexList,
 													translate,
-													scale );
+													scale, needHull);
 		if( ! ok )
 		{
 			DEBUG_PRINT( "SeparateAndCreateFixtures() failed to add any fixtures." );


### PR DESCRIPTION
This upgrade provides better and more optimized vertex handling. More explained in the description of this [PR](<https://github.com/erincatto/box2d/commit/d8e153b9a329c588fcfc734b7a5a5eee1daf6ef0#diff-0d7f64dc8a293089919bdf8ab09d1ad824befbfd23f64e13fe9acf733f5fa5be>).

I did a work to ensure backwards compatibility with Solar2D:

```lua
local image_name = "star.png"

local image_outline = graphics.newOutline( 2, image_name )

local image_star = display.newImageRect( image_name, 32, 32 )

physics.addBody( image_star, { outline=image_outline, needHull = true } )
```

```lua
local pentagonShape = { 0,-37, 37,-10, 23,34, -23,34, -37,-10 }
 
physics.addBody( pentagon, { density=3.0, friction=0.8, bounce=0.3, shape=pentagonShape, needHull = true } )
```

Work with PR

https://github.com/coronalabs/submodule-box2d/pull/8
