### PR TITLE
Fix 16KB support in old ndk version(18.1.5063045).

### DIFF
--- a/platform/android/sdk/CMakeLists.txt
+++ b/platform/android/sdk/CMakeLists.txt
@@ -8,7 +8,7 @@ get_filename_component(CORONA_ROOT "${CMAKE_SOURCE_DIR}/../../.." ABSOLUTE)
 
 set(Lua2CppOutputDir "${CMAKE_CURRENT_BINARY_DIR}/generated_src")
 set(LuaIncludePath "${CORONA_ROOT}/external/lua-5.1.3/src")
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384")
 
 include(AndroidNdkModules)
 android_ndk_import_module_cpufeatures()


### PR DESCRIPTION
The ndk version used in solar2d is 18.1.5063045. According to [this doc](https://developer.android.com/guide/practices/page-sizes?ndk-build=#compile-r22-lower), we should set these two flags:
`-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384`

I found that it's not necessary to set flags in every relevant CMakeLists.txt file; just in "platform/android/sdk/CMakeLists.txt".

See the related issue #820  that this pull request solved.