### PR TITLE
Linux: Rotate left and right added

### DIFF
--- a/platform/linux/src/Rtt_LinuxContext.h
+++ b/platform/linux/src/Rtt_LinuxContext.h
@@ -78,6 +78,7 @@ namespace Rtt
 		int GetHeight() const;
 		void SetHeight(int val);
 		DeviceOrientation::Type GetOrientation() const { return fRuntimeDelegate->fOrientation; }
+		void SetOrientation(DeviceOrientation::Type t) { fRuntimeDelegate->fOrientation = t; }
 		void Flush();
 		bool LoadApp(const std::string& appPath);
 		const std::string& GetAppPath() const { return fPathToApp; }

--- a/platform/linux/src/Rtt_LinuxSimulator.cpp
+++ b/platform/linux/src/Rtt_LinuxSimulator.cpp
@@ -341,6 +341,14 @@ namespace Rtt
 			break;
 		}
 
+		case sdl::OnRotateLeft:
+			OnRotateLeft();
+			break;
+
+		case sdl::OnRotateRight:
+			OnRotateRight();
+			break;
+
 		case sdl::OnZoomIn:
 			OnZoomIn();
 			break;
@@ -383,6 +391,36 @@ namespace Rtt
 		}
 	}
 
+	void SolarSimulator::OnRotateLeft()
+	{
+		SDL_DisplayMode screen;
+		if (SDL_GetCurrentDisplayMode(0, &screen) == 0)
+		{
+			S32 angleAfterRotation = DeviceOrientation::AngleForOrientation(fContext->GetOrientation()) + 90;
+			fContext->SetOrientation(DeviceOrientation::OrientationForAngle(angleAfterRotation));
+
+			int proposedWidth = fContext->GetHeight();
+			int proposedHeight = fContext->GetWidth();
+
+			fContext->SetSize(proposedWidth, proposedHeight);
+		}
+	}
+
+	void SolarSimulator::OnRotateRight()
+	{
+		SDL_DisplayMode screen;
+		if (SDL_GetCurrentDisplayMode(0, &screen) == 0)
+		{
+			S32 angleAfterRotation = DeviceOrientation::AngleForOrientation(fContext->GetOrientation()) - 90;
+			fContext->SetOrientation(DeviceOrientation::OrientationForAngle(angleAfterRotation));
+
+			int proposedWidth = fContext->GetHeight();
+			int proposedHeight = fContext->GetWidth();
+
+			fContext->SetSize(proposedWidth, proposedHeight);
+		}
+	}
+
 	void SolarSimulator::OnZoomOut()
 	{
 		SDL_DisplayMode screen;
@@ -408,8 +446,8 @@ namespace Rtt
 
 			int w = skin->screenWidth;
 			int h = skin->screenHeight;
-			
-			if (!skin->isUprightOrientationPortrait)
+
+			if (DeviceOrientation::IsSideways(fContext->GetOrientation()))
 			{
 				std::swap(w, h);
 			}

--- a/platform/linux/src/Rtt_LinuxSimulator.h
+++ b/platform/linux/src/Rtt_LinuxSimulator.h
@@ -25,6 +25,8 @@ namespace Rtt
 		void OnZoomOut();
 		void OnViewAsChanged(const SkinProperties* skin);
 
+		void OnRotateLeft();
+		void OnRotateRight();
 		void WatchFolder(const std::string& path);
 		bool LoadApp(const std::string& path) override;
 		void SolarEvent(const SDL_Event& e) override;


### PR DESCRIPTION
Added Rotate Left and Right. #834 was not a complete solution because it was making vertical orientation horizontal and vice versa.