### PR TITLE
Apple: iOS and MacOS 26 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ on:
 
 env:
   WORKSPACE: ${{ github.workspace }}
-  DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
   BUILD_NUMBER: ${{ github.event.inputs.buildNumber }}
   YEAR: ${{ github.event.inputs.buildYear }}
 
 jobs:
   source-code:
     name: Check out and process source code
-    runs-on: macos-13
+    runs-on: macos-26
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
 
   native:
     needs: source-code
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
@@ -62,6 +62,47 @@ jobs:
           name: Native
           path: ./output
 
+  Xcode-template-matrix-26:
+    strategy:
+      matrix:
+        runner:
+          - macos-26
+        xcode:
+          - Xcode_26.0
+        target:
+          - template
+          - template-angle
+        platform:
+          - iphone
+          - tvos
+    needs: source-code
+    runs-on: ${{ matrix.runner }}
+    env:
+      DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      TEMPLATE_TARGET: ${{ matrix.target }}
+      TEMPLATE_PLATFORM: ${{ matrix.platform }}
+    steps:
+      - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
+      - name: Get processed code
+        uses: actions/download-artifact@v4
+        with:
+          name: SourceCode
+          path: SourceCode
+      - name: Unpack source code
+        run: tar -xzf SourceCode/corona.tgz
+      - run: ./tools/GHAction/daily_env.sh
+      - name: Build templates
+        working-directory: ./platform/${{ matrix.platform }}
+        run: ./gh_build_templates.sh
+        env:
+          CERT_PASSWORD: ${{ secrets.CertPassword }}
+      - name: Build templates JSON spec
+        run: ./tools/GHAction/generate_xcode_jsons.py
+      - name: Upload templates
+        uses: actions/upload-artifact@v4
+        with:
+          name: Templates-${{ matrix.platform }}-${{ matrix.xcode }}-${{ matrix.target }}
+          path: ./output
   Xcode-template-matrix-15:
     strategy:
       matrix:
@@ -307,7 +348,7 @@ jobs:
       - webtemplate
       # - linux
     if: (! failure() && ! cancelled())
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Get processed code
@@ -404,7 +445,7 @@ jobs:
           exit 1
 
   check-notarization:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Check notarization credentials
         run: |
@@ -428,7 +469,7 @@ jobs:
   webtemplate:
     needs:
       - source-code
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,7 @@ jobs:
 
   collect-ios-templates:
     needs:
+      - Xcode-template-matrix-26
       - Xcode-template-matrix-15
     runs-on: ubuntu-latest
     if: (! failure() && ! cancelled())

--- a/platform/mac/AppDelegate.mm
+++ b/platform/mac/AppDelegate.mm
@@ -254,7 +254,7 @@ static const int       kClearProjectSandboxMenuTag = 1001;
 
 NSString *kosVersionMinimum = @"10.9";   // we refuse to run on OSes older than this
 NSString *kosVersionPrevious = @"10.12";  // should be updated as Apple releases new OSes
-NSString *kosVersionCurrent = @"15.99";  // should be updated as Apple releases new OSes; we will run on this one and the previous one
+NSString *kosVersionCurrent = @"26.99";  // should be updated as Apple releases new OSes; we will run on this one and the previous one
 
 // These tags are defined on the various DeviceBuild dialogs in Interface Builder
 enum {

--- a/tools/CoronaBuilder/BuilderPluginDownloader.lua
+++ b/tools/CoronaBuilder/BuilderPluginDownloader.lua
@@ -439,9 +439,9 @@ function DownloadPluginsMain(args, user, buildYear, buildRevision)
 			end
 		else
 			if forceLoad then			
-				config:write('OTHER_LDFLAGS = $(inherited) $(CORONA_CUSTOM_LDFLAGS) -force_load "$(CORONA_ROOT)/Corona/ios/lib/libplayer.a" \n')
+				config:write('OTHER_LDFLAGS = $(inherited) $(CORONA_CUSTOM_LDFLAGS) -force_load "$(CORONA_ROOT)/Corona/ios/lib/libplayer.a" -Xlinker -undefined -Xlinker dynamic_lookup \n')
 			else
-				config:write('OTHER_LDFLAGS = $(inherited) $(CORONA_CUSTOM_LDFLAGS) -all_load -lplayer\n')
+				config:write('OTHER_LDFLAGS = $(inherited) $(CORONA_CUSTOM_LDFLAGS) -all_load -lplayer -Xlinker -undefined -Xlinker dynamic_lookup\n')
 			end
 		end
 		

--- a/tools/buildsys-ios/libtemplate/Defaults.lua
+++ b/tools/buildsys-ios/libtemplate/Defaults.lua
@@ -161,7 +161,6 @@ function M:updateFlags( minVersion )
 	self.options.flags = {
 		'-ObjC',
 		'-all_load',
-		'-ld_classic',
 		'-fobjc-link-runtime',
 		'-miphoneos-version-min=' .. minVersion,
 		'-std=c++11',


### PR DESCRIPTION
I bumped up support for Xcode 26, iOS and MacOS


Note that -ld_classic is not longer need and including it leads to the following error when building

[ld: Assertion failed: (it != _dylibToOrdinal.end()), function dylibToOrdinal, file OutputFile.cpp, line 5184](https://stackoverflow.com/questions/79677312/ld-assertion-failed-it-dylibtoordinal-end-function-dylibtoordinal-fi)