### PR TITLE
Fix incorrect extraction of the get-task-allow flag from the provisioning profile

### DIFF
--- a/platform/resources/iPhonePackageApp.lua
+++ b/platform/resources/iPhonePackageApp.lua
@@ -518,14 +518,8 @@ local function generateXcent( options )
 		print("get_task_allow_setting: ".. tostring(get_task_allow_setting))
 	end
 	if get_task_allow_setting ~= "" then
-		-- set the value appropriately
-		if get_task_allow_setting == "true" then
-			templateGetTaskAllow, numMatches = string.gsub( templateGetTaskAllow, "{{GET_TASK}}", "true" )
-			assert( numMatches == 1 )
-		else
-			templateGetTaskAllow, numMatches = string.gsub( templateGetTaskAllow, "{{GET_TASK}}", "false" )
-			assert( numMatches == 1 )
-		end
+		templateGetTaskAllow, numMatches = string.gsub( templateGetTaskAllow, "{{GET_TASK}}", get_task_allow_setting )
+		assert( numMatches == 1 )
 		data, numMatches = string.gsub( data, "{{GET_TASK_ALLOW}}", templateGetTaskAllow )
 		assert( numMatches == 1 )
 	else

--- a/platform/resources/tvosPackageApp.lua
+++ b/platform/resources/tvosPackageApp.lua
@@ -885,14 +885,8 @@ local function generateXcent( options )
 		print("get_task_allow_setting: ".. tostring(get_task_allow_setting))
 	end
 	if get_task_allow_setting ~= "" then
-		-- set the value appropriately
-		if get_task_allow_setting == "true" then
-			templateGetTaskAllow, numMatches = string.gsub( templateGetTaskAllow, "{{GET_TASK}}", "true" )
-			assert( numMatches == 1 )
-		else
-			templateGetTaskAllow, numMatches = string.gsub( templateGetTaskAllow, "{{GET_TASK}}", "false" )
-			assert( numMatches == 1 )
-		end
+		templateGetTaskAllow, numMatches = string.gsub( templateGetTaskAllow, "{{GET_TASK}}", get_task_allow_setting )
+		assert( numMatches == 1 )
 		data, numMatches = string.gsub( data, "{{GET_TASK_ALLOW}}", templateGetTaskAllow )
 		assert( numMatches == 1 )
 	else


### PR DESCRIPTION
Fixes an invalid provisioning profile issue I have been facing since I upgraded to Tahoe.

https://forums.solar2d.com/t/ios-deploy-fails-after-macos-upgrade-a-valid-provisioning-profile-for-this-executable-was-not-found/357564

I get this log from the Engine when building with `debugBuildProcess = true`
```get_task_allow_setting:     "get-task-allow" => true```

When the expected is just:
```get_task_allow_setting:     true```

I have been able to resign my app properly with that command, but I haven't been able to test this change from the engine itself.