### PR TITLE
Core: fix box2d joint use after free when world deleted

### DIFF
--- a/librtt/Rtt_PhysicsWorld.cpp
+++ b/librtt/Rtt_PhysicsWorld.cpp
@@ -187,10 +187,13 @@ PhysicsWorld::StopWorld()
 		// iterate over bodies and detach from display object
 		const void *groundBodyUserdata = LuaLibPhysics::GetGroundBodyUserdata();
 
-		for ( b2Body *body = fWorld->GetBodyList();
+		for ( b2Body *body = fWorld->GetBodyList(), *nextBody = NULL;
 			  NULL != body;
-			  body = body->GetNext() )
+			  body = nextBody )
 		{
+			// Prefetch next body before we delete body
+			nextBody = body->GetNext();
+
 			if ( body->GetUserData() )
 			{
 				if ( body->GetUserData() != groundBodyUserdata )
@@ -199,6 +202,8 @@ PhysicsWorld::StopWorld()
 					o->RemoveExtensions();
 				}
 			}
+
+			fWorld->DestroyBody( body );
 		}
 
 		Rtt_DELETE( fWorld );


### PR DESCRIPTION
This PR fix the crashes below iOS 18, not seeing on Android 64-bit and iOS 18+, when `physics.stop()` before clean the _Joint_ lua object.

Here's some clues:

1. [UserdataWrapper](https://github.com/coronalabs/corona/blob/fe82c21accc4d118b8743da01889f4154ac77c44/librtt/Rtt_LuaAux.h#L89) acts as a bridge between the Lua proxy object and the Box2D Joint.
2. Box2D will clean up the mounted Joint and Fixture when destroying the Body, and call SayGoodbye to call back from Box2D to the PhysicsDestructionListener implemented by Solar2D to clear UserdataWrapper's reference to the Joint;
3. When the Box2D World is destroyed, the corresponding memory will be released directly without cleanup process, which causes UserdataWrapper to crash due to illegal memory access when it accesses the Joint again to clear the weak references when the Lua proxy object is reclaimed by GC after the World is destroyed.
4. This PR avoids the above problem by traversing to release the body when StopWorld() and having [Box2D clean up the joint](https://box2d.org/doc_version_2_4/md__e_1_2github_2box2d__24_2docs_2dynamics.html#autotoc_md83).
5. Can reproduced by https://github.com/coronalabs/samples-coronasdk/blob/master/Physics/Chains/main.lua with modified main.lua: [main.lua.txt](https://github.com/user-attachments/files/23092956/main.lua.txt)
