### PR TITLE
Fix box2d physics use-after-free crashes

### DIFF
--- a/librtt/Rtt_DisplayObjectExtensions.cpp
+++ b/librtt/Rtt_DisplayObjectExtensions.cpp
@@ -17,6 +17,7 @@
 #include "Rtt_Lua.h"
 #include "Rtt_LuaContext.h"
 #include "Rtt_LuaLibPhysics.h"
+#include "Rtt_LuaAux.h"
 #include "Rtt_PhysicsWorld.h"
 #include "Rtt_Runtime.h"
 
@@ -42,6 +43,25 @@ DisplayObjectExtensions::~DisplayObjectExtensions()
 #ifdef Rtt_PHYSICS
 	if ( fBody )
 	{
+		// Invalidate UserdataWrappers for all joints attached to this body
+		// BEFORE clearing the body's UserData. When StepWorld later calls
+		// DestroyBody, Box2D will destroy these joints internally. Without
+		// pre-invalidation, the Lua GC could trigger PhysicsJoint::Finalizer
+		// on a dangling b2Joint pointer, causing use-after-free (SIGSEGV in
+		// b2Fixture::Destroy).
+		b2JointEdge *je = fBody->GetJointList();
+		while ( je )
+		{
+			b2Joint *joint = je->joint;
+			UserdataWrapper *wrapper = (UserdataWrapper *)joint->GetUserData();
+			if ( wrapper && UserdataWrapper::GetFinalizedValue() != wrapper )
+			{
+				wrapper->Invalidate();
+			}
+			joint->SetUserData( NULL );
+			je = je->next;
+		}
+
 		// Always clear UserData to prevent StepWorld from dereferencing
 		// a freed DisplayObject. GetParent() returns NULL for objects
 		// with IsRenderedOffScreen (snapshot.group, canvas cache), which

--- a/librtt/Rtt_DisplayObjectExtensions.cpp
+++ b/librtt/Rtt_DisplayObjectExtensions.cpp
@@ -42,23 +42,15 @@ DisplayObjectExtensions::~DisplayObjectExtensions()
 #ifdef Rtt_PHYSICS
 	if ( fBody )
 	{
-		GroupObject *parent = fOwner.GetParent();
-		if ( Rtt_VERIFY( parent ) )
-		{
-			fBody->SetUserData( NULL );
+		// Always clear UserData to prevent StepWorld from dereferencing
+		// a freed DisplayObject. GetParent() returns NULL for objects
+		// with IsRenderedOffScreen (snapshot.group, canvas cache), which
+		// previously caused SetUserData(NULL) to be skipped.
+		fBody->SetUserData( NULL );
 
-			// Do NOT DestroyBody here.  Instead, at end of StepWorld(), we lazily
-			// detect if the body's userdata is NULL. If it is, we know to destroy
-			// the body.
-			/*
-			Runtime *runtime = static_cast< Runtime* >( Rtt_AllocatorGetUserdata( parent->Allocator() ) );
-			b2World *world = runtime->GetWorld();
-			if ( Rtt_VERIFY( world ) )
-			{
-				world->DestroyBody( fBody );
-			}
-			*/
-		}
+		// Do NOT DestroyBody here.  Instead, at end of StepWorld(), we lazily
+		// detect if the body's userdata is NULL. If it is, we know to destroy
+		// the body.
 	}
 #endif // Rtt_PHYSICS
 }

--- a/librtt/Rtt_PhysicsJoint.cpp
+++ b/librtt/Rtt_PhysicsJoint.cpp
@@ -1428,8 +1428,15 @@ PhysicsJoint::Finalizer( lua_State *L )
 		b2Joint *joint = (b2Joint*)wrapper->Dereference();
 		if ( joint )
 		{
-			// Make sure joint no longer points to this wrapper that we're about to destroy
-			joint->SetUserData( NULL );
+			// Only clear userdata if the joint still points back to this wrapper.
+			// If it doesn't, the joint may have already been destroyed by
+			// DestroyBody/DestroyJoint (SayGoodbye already invalidated the wrapper),
+			// and the pointer could be dangling or reused memory.
+			void *userData = joint->GetUserData();
+			if ( userData == wrapper )
+			{
+				joint->SetUserData( NULL );
+			}
 		}
 
 		Rtt_DELETE( wrapper );

--- a/librtt/Rtt_PhysicsWorld.cpp
+++ b/librtt/Rtt_PhysicsWorld.cpp
@@ -181,19 +181,19 @@ PhysicsWorld::StopWorld()
 		SetProperty( kIsWorldRunning, false );
 
 		fWorld->SetContactListener( NULL );
+		fWorld->SetDestructionListener( NULL );
 
-		// The b2World is about to destroy the block allocator that owns
-		// the memory for b2Body objects, so we have to pre-emptively
-		// iterate over bodies and detach from display object
 		const void *groundBodyUserdata = LuaLibPhysics::GetGroundBodyUserdata();
 
-		for ( b2Body *body = fWorld->GetBodyList(), *nextBody = NULL;
+		// Phase 1: Detach display objects from physics bodies.
+		// We do NOT call DestroyBody here — doing so during bulk shutdown
+		// causes use-after-free when DestroyBody(bodyA) calls DestroyJoint
+		// and modifies bodyB which may have already been freed, or when
+		// the block allocator reuses freed joint memory (zeroing the vtable).
+		for ( b2Body *body = fWorld->GetBodyList();
 			  NULL != body;
-			  body = nextBody )
+			  body = body->GetNext() )
 		{
-			// Prefetch next body before we delete body
-			nextBody = body->GetNext();
-
 			if ( body->GetUserData() )
 			{
 				if ( body->GetUserData() != groundBodyUserdata )
@@ -202,10 +202,26 @@ PhysicsWorld::StopWorld()
 					o->RemoveExtensions();
 				}
 			}
-
-			fWorld->DestroyBody( body );
 		}
 
+		// Phase 2: Invalidate any remaining joint wrappers so that
+		// Lua GC finalizers won't access freed b2Joint memory later.
+		void *finalizedUserdata = UserdataWrapper::GetFinalizedValue();
+		for ( b2Joint *joint = fWorld->GetJointList();
+			  NULL != joint;
+			  joint = joint->GetNext() )
+		{
+			UserdataWrapper *wrapper = (UserdataWrapper *)joint->GetUserData();
+			if ( wrapper && finalizedUserdata != wrapper )
+			{
+				wrapper->Invalidate();
+			}
+		}
+
+		// Phase 3: Delete the world. ~b2World cleans up fixture shape
+		// allocations, and ~b2BlockAllocator bulk-frees all body/joint/
+		// fixture memory. This avoids the complex per-body DestroyBody →
+		// DestroyJoint chain that caused joint double-free crashes.
 		Rtt_DELETE( fWorld );
 		fWorld = NULL;
 


### PR DESCRIPTION
# Fix physics use-after-free crashes

## Summary

Fix multiple use-after-free vulnerabilities in the Box2D physics binding that cause `SIGSEGV` crashes in production (Our Google Play App).

- **StopWorld 3-phase cleanup**: Replace per-body `DestroyBody` loop with bulk cleanup to eliminate double-free when gear joints have `m_bodyA == m_bodyB` (both edges in same body's joint list)
- **StepWorld offscreen fix**: Remove `GetParent()` guard in `~DisplayObjectExtensions` so offscreen display objects (`snapshot.group`, canvas texture cache) unconditionally clear `body->SetUserData(NULL)`, preventing dangling pointer dereference on next frame. The same as this PR: #894
- **Finalizer ownership check**: Add bidirectional `joint->GetUserData() == wrapper` guard before writing to `b2Joint` userdata in Lua GC finalizer
- **Pre-invalidate joint wrappers**: Invalidate all attached joint `UserdataWrapper`s immediately in `~DisplayObjectExtensions`, closing the GC timing window between `removeSelf` and `StepWorld`'s deferred `DestroyBody`

## Crash signatures (from production)

```
[libcorona.so] b2Fixture::Destroy(b2BlockAllocator*) SIGSEGV
[libcorona.so] PhysicsJoint::Finalizer                SIGSEGV
[Corona Simulator] b2Joint::Destroy + 32               SIGSEGV at 0x0
```

## Prior fix context
 This PR #858 (commit `c8c3bd1e`) ("Core: fix box2d joint use after free when world deleted") added `DestroyBody(body)` to the `StopWorld`    loop. This fixed the original bug where `delete fWorld` bulk-freed all joint memory without calling `SayGoodbye`, leaving     joint wrappers dangling for the GC Finalizer to crash on. With `DestroyBody`, each joint gets `SayGoodbye` → `wrapper->Invalidate()` before being freed, making the Finalizer safe for **all normal joints**.

However, `DestroyBody` introduced a new deterministic crash for **gear joints**: `b2GearJoint` has `m_bodyA == m_bodyB == ground`, so both joint edges are in the same body's list, and `DestroyBody(ground)` double-frees the gear joint.

This PR's 3-phase `StopWorld` solves both problems simultaneously: no `DestroyBody` (avoids gear joint double-free), but manually iterates the joint list to `wrapper->Invalidate()` (replaces `SayGoodbye`'s role).


## Gear joint deterministic crash — test code

The gear joint crash is 100% reproducible. `b2GearJoint` overrides `m_bodyA`/`m_bodyB` to the sub-joints' other bodies, causing both joint edges to register in the same body's list (ground). When `DestroyBody(ground)` iterates this list, it frees the gear joint via `edgeB`, then follows the prefetched `next` pointer to `edgeA` — which is now freed memory.

Paste into `main.lua` and run — crashes immediately on `physics.stop()`:

```lua
local physics = require("physics")
physics.start()
physics.setGravity(0, 9.8)

-- Bodies
local ground = display.newRect(160, 450, 320, 20)
physics.addBody(ground, "static")

local wheelA = display.newCircle(100, 300, 30)
physics.addBody(wheelA, "dynamic", { radius = 30, density = 1.0 })

local wheelB = display.newCircle(220, 300, 30)
physics.addBody(wheelB, "dynamic", { radius = 30, density = 1.0 })

-- Two pivot joints anchored to ground
local pivotA = physics.newJoint("pivot", wheelA, ground, 100, 300)
local pivotB = physics.newJoint("pivot", wheelB, ground, 220, 300)

-- Gear joint links the two pivots — internally sets m_bodyA = m_bodyB = ground
local gearJoint = physics.newJoint("gear", wheelA, wheelB, pivotA, pivotB, 1.5)

-- Stop physics after a short delay → StopWorld → DestroyBody(ground) → SIGSEGV
timer.performWithDelay(500, function()
    physics.stop()  -- deterministic crash: b2Joint::Destroy + 32, SIGSEGV at 0x0
end)
```