### PR TITLE
Add display.isValidObject function

### DIFF
--- a/librtt/Display/Rtt_GroupObject.cpp
+++ b/librtt/Display/Rtt_GroupObject.cpp
@@ -85,6 +85,7 @@ GroupObject::ReleaseChildrenLuaReferences( lua_State *L )
 GroupObject::GroupObject( Rtt_Allocator* pAllocator, StageObject* canvas )
 :    Super(),
     fStage( canvas ),
+    fOwner( NULL ),
     fChildren( pAllocator )
 {
     SetObjectDesc("GroupObject"); // for introspection

--- a/librtt/Display/Rtt_GroupObject.h
+++ b/librtt/Display/Rtt_GroupObject.h
@@ -64,6 +64,13 @@ class GroupObject : public DisplayObject
 		void SetStage( StageObject* canvas ) { fStage = canvas; }
 
 	public:
+		// Owning display object for internal groups outside the parent hierarchy
+		// (e.g. snapshot.group/snapshot.canvas); NULL for ordinary groups.
+		DisplayObject* GetOwner() { return fOwner; }
+		const DisplayObject* GetOwner() const { return fOwner; }
+		void SetOwner( DisplayObject* owner ) { fOwner = owner; }
+
+	public:
 		S32 NumChildren() const { return fChildren.Length(); }
 		const DisplayObject& ChildAt( S32 index ) const { return * fChildren[index]; }
 		DisplayObject& ChildAt( S32 index ) { return * fChildren[index]; }
@@ -86,6 +93,7 @@ class GroupObject : public DisplayObject
 
 	private:
 		StageObject* fStage;
+		DisplayObject* fOwner;
 
 	protected:
 		// Children are drawn in order, i.e. first child is drawn below the second

--- a/librtt/Display/Rtt_LuaLibDisplay.cpp
+++ b/librtt/Display/Rtt_LuaLibDisplay.cpp
@@ -1143,7 +1143,9 @@ DisplayLibrary::newImage( lua_State *L )
         Runtime& runtime = library->GetDisplay().GetRuntime();
         BitmapPaint *paint = BitmapPaint::NewBitmap( runtime, imageName, baseDir, flags );
 
-        if ( paint && paint->GetBitmap() && paint->GetBitmap()->NumBytes() == 0 )
+        bool isInvalid = paint && paint->GetBitmap() && paint->GetBitmap()->NumBytes() == 0;
+
+        if ( isInvalid )
         {
             CoronaLuaWarning(L, "file '%s' does not contain a valid image", imageName);
         }
@@ -1151,6 +1153,12 @@ DisplayLibrary::newImage( lua_State *L )
         if ( paint )
         {
             result = NULL != PushImage( L, p, paint, display, parent, replacement );
+            if ( result && isInvalid )
+            {
+                lua_pushstring( L, "_isInvalid" );
+                lua_pushboolean( L, 1 );
+                lua_rawset( L, -3 );
+            }
         }
     }
     else if ( lua_isuserdata( L, nextArg ) )
@@ -1257,13 +1265,21 @@ DisplayLibrary::newImageRect( lua_State *L )
             Runtime& runtime = library->GetDisplay().GetRuntime();
             BitmapPaint *paint = BitmapPaint::NewBitmap( runtime, imageName, baseDir, flags );
 
-            if ( paint && paint->GetBitmap() && paint->GetBitmap()->NumBytes() == 0 )
+            bool isInvalid = paint && paint->GetBitmap() && paint->GetBitmap()->NumBytes() == 0;
+
+            if ( isInvalid )
             {
                 CoronaLuaWarning(L, "file '%s' does not contain a valid image", imageName);
             }
             if ( Rtt_VERIFY( paint ) )
             {
                 result = NULL != PushImage( L, NULL, paint, display, parent, w, h, replacement );
+                if ( result && isInvalid )
+                {
+                    lua_pushstring( L, "_isInvalid" );
+                    lua_pushboolean( L, 1 );
+                    lua_rawset( L, -3 );
+                }
             }
         }
         else

--- a/librtt/Display/Rtt_LuaLibDisplay.cpp
+++ b/librtt/Display/Rtt_LuaLibDisplay.cpp
@@ -160,6 +160,7 @@ class DisplayLibrary
         static int getDefault( lua_State *L );
         static int setDefault( lua_State *L );
         static int getCurrentStage( lua_State *L );
+        static int isValidObject( lua_State *L );
         static int collectOrphans( lua_State *L );
         static int setStatusBar( lua_State *L );
         static int capture( lua_State *L );
@@ -240,6 +241,7 @@ DisplayLibrary::Open( lua_State *L )
         { "getDefault", getDefault },
         { "setDefault", setDefault },
         { "getCurrentStage", getCurrentStage },
+        { "isValidObject", isValidObject },
         { "_collectOrphans", collectOrphans },
         { "setStatusBar", setStatusBar },
         { "capture", capture },
@@ -2286,6 +2288,61 @@ DisplayLibrary::getCurrentStage( lua_State *L )
     Display& display = library->GetDisplay();
 
     return display.GetStage()->GetProxy()->PushTable( L );
+}
+
+// Returns whether the argument is a usable display object: its native object
+// exists, it was not flagged invalid at creation, and neither it nor any
+// ancestor has been removed (removed objects are parented into an orphanage).
+int
+DisplayLibrary::isValidObject( lua_State *L )
+{
+    bool isValid = false;
+
+    if ( lua_istable( L, 1 ) && LuaProxy::IsProxy( L, 1 ) )
+    {
+        DisplayObject *object = (DisplayObject*)LuaProxy::GetProxyableObject( L, 1 );
+
+        if ( object )
+        {
+            // Set by newImage/newImageRect when the image file could not be decoded
+            lua_pushstring( L, "_isInvalid" );
+            lua_rawget( L, 1 );
+            bool isInvalid = lua_toboolean( L, -1 );
+            lua_pop( L, 1 );
+
+            if ( ! isInvalid )
+            {
+                Self *library = ToLibrary( L );
+                Display& display = library->GetDisplay();
+
+                // Walk to the hierarchy root; parentless internal groups
+                // (snapshot.group/snapshot.canvas) continue from their owner.
+                DisplayObject *root = object;
+                for ( ;; )
+                {
+                    DisplayObject *next = root->GetParent();
+
+                    if ( ! next )
+                    {
+                        GroupObject *group = root->AsGroupObject();
+                        next = group ? group->GetOwner() : NULL;
+                    }
+
+                    if ( ! next )
+                    {
+                        break;
+                    }
+
+                    root = next;
+                }
+
+                isValid = root != display.Orphanage() && root != display.HitTestOrphanage();
+            }
+        }
+    }
+
+    lua_pushboolean( L, isValid );
+    return 1;
 }
 
 /*

--- a/librtt/Display/Rtt_SnapshotObject.cpp
+++ b/librtt/Display/Rtt_SnapshotObject.cpp
@@ -137,6 +137,10 @@ SnapshotObject::SnapshotObject(
 	fGroup->SetRenderedOffScreen( true );
 	fCanvas->SetRenderedOffScreen( true );
 
+	// Lets ancestry walks (e.g. display.isValidObject) continue from the snapshot
+	fGroup->SetOwner( this );
+	fCanvas->SetOwner( this );
+
     SetObjectDesc( "SnapshotObject" );     // for introspection
 }
 

--- a/librtt/Rtt_LuaProxyVTable.cpp
+++ b/librtt/Rtt_LuaProxyVTable.cpp
@@ -3846,6 +3846,83 @@ LuaGroupObjectProxyVTable::Constant()
     return kVTable;
 }
 
+// Marks a single object as removed via its Lua proxy table
+static void
+MarkObjectAsRemoved( lua_State *L, DisplayObject* object )
+{
+    LuaProxy* proxy = object->GetProxy();
+    if ( proxy )
+    {
+        proxy->PushTable( L );
+        lua_pushstring( L, "_isRemoved" );
+        lua_pushboolean( L, 1 );
+        lua_rawset( L, -3 );
+        lua_pop( L, 1 );
+    }
+}
+
+// Forward declaration for MarkSnapshotInternalsAsRemoved <-> MarkDescendantsAsRemoved recursion.
+static void MarkDescendantsAsRemoved( lua_State *L, GroupObject* group );
+
+// SnapshotObject extends RectObject, not GroupObject, so snapshot.group and
+// snapshot.canvas are not walked by the normal child cascade. Mark them and their
+// contents explicitly.
+static void
+MarkSnapshotInternalsAsRemoved( lua_State *L, SnapshotObject* snap )
+{
+    GroupObject& snapshotGroup = snap->GetGroup();
+    MarkObjectAsRemoved( L, &snapshotGroup );
+    MarkDescendantsAsRemoved( L, &snapshotGroup );
+
+    GroupObject& snapshotCanvas = snap->GetCanvas();
+    MarkObjectAsRemoved( L, &snapshotCanvas );
+    MarkDescendantsAsRemoved( L, &snapshotCanvas );
+}
+
+// Recursively marks all descendants of a group as removed
+static void
+MarkDescendantsAsRemoved( lua_State *L, GroupObject* group )
+{
+    for ( S32 i = group->NumChildren(); --i >= 0; )
+    {
+        DisplayObject& child = group->ChildAt( i );
+        MarkObjectAsRemoved( L, &child );
+
+        GroupObject* subGroup = child.AsGroupObject();
+        if ( subGroup )
+        {
+            MarkDescendantsAsRemoved( L, subGroup );
+        }
+        else if ( &child.ProxyVTable() == &LuaSnapshotObjectProxyVTable::Constant() )
+        {
+            MarkSnapshotInternalsAsRemoved( L, static_cast< SnapshotObject* >( &child ) );
+        }
+    }
+}
+
+// Recursively clears _isRemoved flag on an object and all descendants
+static void
+ClearRemovedFlag( lua_State *L, DisplayObject* object )
+{
+    LuaProxy* proxy = object->GetProxy();
+    if ( proxy )
+    {
+        proxy->PushTable( L );
+        lua_pushstring( L, "_isRemoved" );
+        lua_pushnil( L );
+        lua_rawset( L, -3 );
+        lua_pop( L, 1 );
+    }
+    GroupObject* group = object->AsGroupObject();
+    if ( group )
+    {
+        for ( S32 i = group->NumChildren(); --i >= 0; )
+        {
+            ClearRemovedFlag( L, &group->ChildAt( i ) );
+        }
+    }
+}
+
 int
 LuaGroupObjectProxyVTable::Insert( lua_State *L, GroupObject *parent )
 {
@@ -3897,13 +3974,31 @@ LuaGroupObjectProxyVTable::Insert( lua_State *L, GroupObject *parent )
             if ( oldParent != parent )
             {
                 StageObject* canvas = parent->GetStage();
-                if ( canvas && oldParent == canvas->GetDisplay().Orphanage() )
+                if ( canvas )
                 {
-                    lua_pushvalue( L, childIndex ); // push table representing child
-                    child->GetProxy()->AcquireTableRef( L ); // reacquire a ref for table
-                    lua_pop( L, 1 );
+                    if ( oldParent == canvas->GetDisplay().Orphanage() )
+                    {
+                        lua_pushvalue( L, childIndex ); // push table representing child
+                        child->GetProxy()->AcquireTableRef( L ); // reacquire a ref for table
+                        lua_pop( L, 1 );
 
-                    child->WillMoveOnscreen();
+                        child->WillMoveOnscreen();
+                    }
+
+                    // Clear _isRemoved on re-insertion; flag may be set directly or via
+                    // MarkDescendantsAsRemoved on an ancestor.
+                    LuaProxy* proxy = child->GetProxy();
+                    if ( proxy )
+                    {
+                        proxy->PushTable( L );
+                        lua_getfield( L, -1, "_isRemoved" );
+                        bool wasMarkedRemoved = lua_toboolean( L, -1 );
+                        lua_pop( L, 2 );
+                        if ( wasMarkedRemoved )
+                        {
+                            ClearRemovedFlag( L, child );
+                        }
+                    }
                 }
             }
         }
@@ -3943,8 +4038,15 @@ LuaDisplayObjectProxyVTable::PushAndRemove( lua_State *L, GroupObject* parent, S
 		StageObject *stage = parent->GetStage();
 		if ( stage )
 		{
-			Rtt_ASSERT( LuaContext::GetRuntime( L )->GetDisplay().HitTestOrphanage() != parent
-						&& LuaContext::GetRuntime( L )->GetDisplay().Orphanage() != parent );
+			Display& display = LuaContext::GetRuntime( L )->GetDisplay();
+			if ( display.HitTestOrphanage() == parent || display.Orphanage() == parent )
+			{
+				// Parent is already the orphanage: the object is mid-removal.
+				// Treat as a no-op so double-remove (direct, or via stale
+				// reference after a parent group was removed) stays safe.
+				lua_pushnil( L );
+				return;
+			}
 
 			SUMMED_TIMING( par1, "Object: PushAndRemove (release)" );
 
@@ -3972,14 +4074,30 @@ LuaDisplayObjectProxyVTable::PushAndRemove( lua_State *L, GroupObject* parent, S
                 LuaProxy* proxy = child->GetProxy();
                 proxy->PushTable( L );
 
+                // Mark the object as removed for immediate Lua-side detection
+                lua_pushstring( L, "_isRemoved" );
+                lua_pushboolean( L, 1 );
+                lua_rawset( L, -3 );
+
+                // If the object is a group, recursively mark all descendants.
+                // Snapshots are not GroupObjects but expose internal snapshot.group /
+                // snapshot.canvas via their proxy, so cascade those separately.
+                GroupObject* childGroup = child->AsGroupObject();
+                if ( childGroup )
+                {
+                    MarkDescendantsAsRemoved( L, childGroup );
+                }
+                else if ( &child->ProxyVTable() == &LuaSnapshotObjectProxyVTable::Constant() )
+                {
+                    MarkSnapshotInternalsAsRemoved( L, static_cast< SnapshotObject* >( child ) );
+                }
+
                 // Rtt_TRACE( ( "release table ref(%x)\n", lua_topointer( L, -1 ) ) );
 
                 // Anytime we add to the Orphanage, it means the DisplayObject is no
                 // longer on the display. Therefore, we should luaL_unref the
                 // DisplayObject's table. If it's later re-inserted, then we simply
                 // luaL_ref the incoming table.
-                Display& display = LuaContext::GetRuntime( L )->GetDisplay();
-
 
                 // NOTE: Snapshot renamed to HitTest orphanage to clarify usage
                 // TODO: Remove snapshot orphanage --- or verify that we still need it?

--- a/librtt/Rtt_LuaProxyVTable.cpp
+++ b/librtt/Rtt_LuaProxyVTable.cpp
@@ -3846,83 +3846,6 @@ LuaGroupObjectProxyVTable::Constant()
     return kVTable;
 }
 
-// Marks a single object as removed via its Lua proxy table
-static void
-MarkObjectAsRemoved( lua_State *L, DisplayObject* object )
-{
-    LuaProxy* proxy = object->GetProxy();
-    if ( proxy )
-    {
-        proxy->PushTable( L );
-        lua_pushstring( L, "_isRemoved" );
-        lua_pushboolean( L, 1 );
-        lua_rawset( L, -3 );
-        lua_pop( L, 1 );
-    }
-}
-
-// Forward declaration for MarkSnapshotInternalsAsRemoved <-> MarkDescendantsAsRemoved recursion.
-static void MarkDescendantsAsRemoved( lua_State *L, GroupObject* group );
-
-// SnapshotObject extends RectObject, not GroupObject, so snapshot.group and
-// snapshot.canvas are not walked by the normal child cascade. Mark them and their
-// contents explicitly.
-static void
-MarkSnapshotInternalsAsRemoved( lua_State *L, SnapshotObject* snap )
-{
-    GroupObject& snapshotGroup = snap->GetGroup();
-    MarkObjectAsRemoved( L, &snapshotGroup );
-    MarkDescendantsAsRemoved( L, &snapshotGroup );
-
-    GroupObject& snapshotCanvas = snap->GetCanvas();
-    MarkObjectAsRemoved( L, &snapshotCanvas );
-    MarkDescendantsAsRemoved( L, &snapshotCanvas );
-}
-
-// Recursively marks all descendants of a group as removed
-static void
-MarkDescendantsAsRemoved( lua_State *L, GroupObject* group )
-{
-    for ( S32 i = group->NumChildren(); --i >= 0; )
-    {
-        DisplayObject& child = group->ChildAt( i );
-        MarkObjectAsRemoved( L, &child );
-
-        GroupObject* subGroup = child.AsGroupObject();
-        if ( subGroup )
-        {
-            MarkDescendantsAsRemoved( L, subGroup );
-        }
-        else if ( &child.ProxyVTable() == &LuaSnapshotObjectProxyVTable::Constant() )
-        {
-            MarkSnapshotInternalsAsRemoved( L, static_cast< SnapshotObject* >( &child ) );
-        }
-    }
-}
-
-// Recursively clears _isRemoved flag on an object and all descendants
-static void
-ClearRemovedFlag( lua_State *L, DisplayObject* object )
-{
-    LuaProxy* proxy = object->GetProxy();
-    if ( proxy )
-    {
-        proxy->PushTable( L );
-        lua_pushstring( L, "_isRemoved" );
-        lua_pushnil( L );
-        lua_rawset( L, -3 );
-        lua_pop( L, 1 );
-    }
-    GroupObject* group = object->AsGroupObject();
-    if ( group )
-    {
-        for ( S32 i = group->NumChildren(); --i >= 0; )
-        {
-            ClearRemovedFlag( L, &group->ChildAt( i ) );
-        }
-    }
-}
-
 int
 LuaGroupObjectProxyVTable::Insert( lua_State *L, GroupObject *parent )
 {
@@ -3974,31 +3897,13 @@ LuaGroupObjectProxyVTable::Insert( lua_State *L, GroupObject *parent )
             if ( oldParent != parent )
             {
                 StageObject* canvas = parent->GetStage();
-                if ( canvas )
+                if ( canvas && oldParent == canvas->GetDisplay().Orphanage() )
                 {
-                    if ( oldParent == canvas->GetDisplay().Orphanage() )
-                    {
-                        lua_pushvalue( L, childIndex ); // push table representing child
-                        child->GetProxy()->AcquireTableRef( L ); // reacquire a ref for table
-                        lua_pop( L, 1 );
+                    lua_pushvalue( L, childIndex ); // push table representing child
+                    child->GetProxy()->AcquireTableRef( L ); // reacquire a ref for table
+                    lua_pop( L, 1 );
 
-                        child->WillMoveOnscreen();
-                    }
-
-                    // Clear _isRemoved on re-insertion; flag may be set directly or via
-                    // MarkDescendantsAsRemoved on an ancestor.
-                    LuaProxy* proxy = child->GetProxy();
-                    if ( proxy )
-                    {
-                        proxy->PushTable( L );
-                        lua_getfield( L, -1, "_isRemoved" );
-                        bool wasMarkedRemoved = lua_toboolean( L, -1 );
-                        lua_pop( L, 2 );
-                        if ( wasMarkedRemoved )
-                        {
-                            ClearRemovedFlag( L, child );
-                        }
-                    }
+                    child->WillMoveOnscreen();
                 }
             }
         }
@@ -4041,9 +3946,8 @@ LuaDisplayObjectProxyVTable::PushAndRemove( lua_State *L, GroupObject* parent, S
 			Display& display = LuaContext::GetRuntime( L )->GetDisplay();
 			if ( display.HitTestOrphanage() == parent || display.Orphanage() == parent )
 			{
-				// Parent is already the orphanage: the object is mid-removal.
-				// Treat as a no-op so double-remove (direct, or via stale
-				// reference after a parent group was removed) stays safe.
+				// Parent is an orphanage, so the object was already removed;
+				// removing it again is a no-op.
 				lua_pushnil( L );
 				return;
 			}
@@ -4073,24 +3977,6 @@ LuaDisplayObjectProxyVTable::PushAndRemove( lua_State *L, GroupObject* parent, S
                 Rtt_ASSERT( child->IsReachable() );
                 LuaProxy* proxy = child->GetProxy();
                 proxy->PushTable( L );
-
-                // Mark the object as removed for immediate Lua-side detection
-                lua_pushstring( L, "_isRemoved" );
-                lua_pushboolean( L, 1 );
-                lua_rawset( L, -3 );
-
-                // If the object is a group, recursively mark all descendants.
-                // Snapshots are not GroupObjects but expose internal snapshot.group /
-                // snapshot.canvas via their proxy, so cascade those separately.
-                GroupObject* childGroup = child->AsGroupObject();
-                if ( childGroup )
-                {
-                    MarkDescendantsAsRemoved( L, childGroup );
-                }
-                else if ( &child->ProxyVTable() == &LuaSnapshotObjectProxyVTable::Constant() )
-                {
-                    MarkSnapshotInternalsAsRemoved( L, static_cast< SnapshotObject* >( child ) );
-                }
 
                 // Rtt_TRACE( ( "release table ref(%x)\n", lua_topointer( L, -1 ) ) );
 

--- a/platform/resources/init.lua
+++ b/platform/resources/init.lua
@@ -575,6 +575,13 @@ display.remove = function( object )
 	end
 end
 
+-- check if object is a valid, usable display object.
+-- removeSelf confirms it's a display object. _isRemoved is set by the engine at the moment of removal, bypassing the one-frame delay where
+-- an object's properties are still valid. _isInvalid is set by display.newImage / newImageRect when the file is not an image or is corrupted.
+display.isValidObject = function( object )
+	return "table" == type( object ) and "function" == type( object.removeSelf ) and not (object._isRemoved or object._isInvalid)
+end
+
 -- display function to create retina-compatible text for double-pixel devices
 function display.newRetinaText( ... )
 	print( "WARNING: display.newRetinaText() has been deprecated. display.newText() is now retina-aware." )

--- a/platform/resources/init.lua
+++ b/platform/resources/init.lua
@@ -575,13 +575,6 @@ display.remove = function( object )
 	end
 end
 
--- check if object is a valid, usable display object.
--- removeSelf confirms it's a display object. _isRemoved is set by the engine at the moment of removal, bypassing the one-frame delay where
--- an object's properties are still valid. _isInvalid is set by display.newImage / newImageRect when the file is not an image or is corrupted.
-display.isValidObject = function( object )
-	return "table" == type( object ) and "function" == type( object.removeSelf ) and not (object._isRemoved or object._isInvalid)
-end
-
 -- display function to create retina-compatible text for double-pixel devices
 function display.newRetinaText( ... )
 	print( "WARNING: display.newRetinaText() has been deprecated. display.newText() is now retina-aware." )


### PR DESCRIPTION
# display.isValidObject

Adds a Lua-level API for checking whether a given object is a valid display object that has not been removed.

## Current behaviour

### Object removal

Calling `display.remove( object )` or `object:removeSelf()` will take until the next frame to finish removing the object. In certain situations, like with collision events, callbacks, etc. it's possible that an object has been removed, but the removal isn't yet finished, which results in a crash if the app tries to access the object.

Example
```lua
local rect = display.newRect( 100, 100, 50, 50 )
display.remove( rect )

print( rect.x ) -- output: 100

timer.performWithDelay( 1, function()
    print( rect.x )    -- output: nil
end )
```

There is currently no reliable way to programmatically checking if a display object has already been removed and developers need to implement their own ad-hoc approaches to test for it.

### Image object validity

Solar2D detects when `display.newImage` or `display.newImageRect` is given a file that is not an image, or if the image is corrupted or otherwise invalid. Solar2D sends a warning about it to console via `CoronaLuaWarning(L, "file '%s' does not contain a valid image", imageName);`. Funnily enough, Solar2D does not currently provide a reliable way to check this programmatically.

## What this PR does

This PR adds two internal proxy flags to objects,  `_isRemoved` and `_isInvalid`, that the engine sets at the moment an object is removed or when Solar2D detects an image is invalid upon trying to create it.

This PR also adds a new  `display.isValidObject( object )` that verifies if a given object is 1) a display object, 2) it has not been removed, and 3) it is not invalid. The function always return a Boolean value, giving developers a reliable way of checking if their display objects are indeed valid or not.

Example

Example
```lua
local rect = display.newRect( 100, 100, 50, 50 )
print( display.isValidObject( rect ) ) -- output: true
display.remove( rect )

print( display.isValidObject( rect ) ) -- output: false

timer.performWithDelay( 1, function()
    print( display.isValidObject( rect ) ) -- output: false
end )
```

### Unit tests

The test project runs 18 unit tests that exercise `display.isValidObject` across all the edge cases: type safety with non-display-object inputs (nil, numbers, strings, tables, functions), removal via `display.remove` and `removeSelf`, idempotent double-removal, stage validity, group cascade at various nesting depths, `finalize` listener timing, same-frame re-parent rescue for both groups and snapshots, every display primitive type (rect, circle, line, polygon, text, container, snapshot, group, capture), widgets, sprites, emitters, snapshot internals (`snapshot.group` and `snapshot.canvas` with children), and corrupt/missing images via `newImage` and `newImageRect` to verify the `_isInvalid` flag. Each test checks `isValidObject` before removal, same-frame after removal, and next-frame after removal, reporting pass/fail.

[isValidObject test.zip](https://github.com/user-attachments/files/26802971/isValidObject.test.zip)
