### PR TITLE
Fix/windows simulator arrow key

### DIFF
--- a/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinInputDeviceManager.cpp
+++ b/platform/windows/Corona.Native.Library.Win32/Rtt/Rtt_WinInputDeviceManager.cpp
@@ -1028,6 +1028,16 @@ void WinInputDeviceManager::OnReceivedMessage(
 					arguments.SetReturnResult(0);
 					arguments.SetHandled();
 				}
+
+				// Prevent VK_UP/VK_DOWN from reaching DefWindowProc. On this window,
+				// unhandled up/down arrow keys are routed by Win32 keyboard navigation to a
+				// split button control in the UI, triggering BCM_SETDROPDOWNSTATE messages
+				// that disrupt render loop timing. VK_LEFT/VK_RIGHT do not exhibit this behavior.
+				if (keyCode == VK_UP || keyCode == VK_DOWN)
+				{
+					arguments.SetReturnResult(0);
+					arguments.SetHandled();
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
This is a related to https://github.com/coronalabs/corona/pull/405 (Simulator performance fix: treat repeated keys as handled)

**Summary**
On the Windows Simulator, pressing the Up or Down arrow keys causes a latency spike, noticeable visually when pressed repeatedly.

**Root cause**
When a Lua key listener does not return true, the WM_KEYDOWN message is left unhandled and falls through to DefWindowProc. Win32 keyboard navigation routes VK_UP and VK_DOWN to a split button control present in the simulator UI, triggering a pair of synchronous BCM_SETDROPDOWNSTATE messages (set True, immediately set False) on every keypress. This synchronous round-trip into the button control's window procedure disrupts the update/render loop's timing. VK_LEFT/VK_RIGHT do not trigger this behavior.
This was confirmed via MS Spy++ message logging on the render surface window:
```
<000231> 000408EA P WM_KEYDOWN nVirtKey:VK_DOWN cRepeat:1 ScanCode:50 fExtended:1 fAltDown:0 fRepeat:0 fUp:0
<000232> 000408EA S BCM_SETDROPDOWNSTATE fDropDown:True
<000233> 000408EA R BCM_SETDROPDOWNSTATE fSucceeded:False
<000234> 000408EA S BCM_SETDROPDOWNSTATE fDropDown:False
<000235> 000408EA R BCM_SETDROPDOWNSTATE fSucceeded:False
```

**Fix**
In the else branch of the key event handler (i.e. when Lua did not handle the key), VK_UP and VK_DOWN are now explicitly marked as handled so they never reach DefWindowProc. This is consistent with how the back key is already handled in the same branch.

**Testing**
- Confirmed via Spy++ that BCM_SETDROPDOWNSTATE is no longer triggered by Up/Down keypresses after the fix
- No jitter/spikes detected on a profiler when pressing Up/Down arrow keys in the Windows Simulator
- Left/Right arrow keys, character keys, and modifier keys unaffected
- Back key behavior unaffected
- Lua key listeners that return true continue to work as before
- Navigating Simulator UI with arrow keys unaffected