### PR TITLE
HTML5: fix various crashes with image files

### DIFF
--- a/librtt/Display/Rtt_TextureFactory.cpp
+++ b/librtt/Display/Rtt_TextureFactory.cpp
@@ -278,7 +278,12 @@ TextureFactory::FindOrCreate(
 	if ( result.IsNull() )
 	{
 		PlatformBitmap *bitmap = CreateBitmap( filePath.GetString(), flags, isMask );
-		result = CreateAndAdd( key, bitmap, true, isRetina );
+
+		// Guards the NULL bitmap Linux returns on a failed load; no-op on emscripten (returns an empty bitmap).
+		if ( bitmap )
+		{
+			result = CreateAndAdd( key, bitmap, true, isRetina );
+		}
 	}
 
 	return result;

--- a/platform/emscripten/Rtt_EmscriptenBitmap.cpp
+++ b/platform/emscripten/Rtt_EmscriptenBitmap.cpp
@@ -210,6 +210,11 @@ namespace Rtt
 				{
 					fFormat = kRGBA;
 				}
+				else
+				{
+					fWidth = 0;
+					fHeight = 0;
+				}
 				fclose(f);
 			}
 		}
@@ -241,6 +246,11 @@ namespace Rtt
 						}
 					}
 					free(img);
+				}
+				else
+				{
+					fWidth = 0;
+					fHeight = 0;
 				}
 				fclose(f);
 				return fData != NULL;

--- a/platform/emscripten/Rtt_EmscriptenBitmap.cpp
+++ b/platform/emscripten/Rtt_EmscriptenBitmap.cpp
@@ -16,6 +16,8 @@
 #include "Core/Rtt_Types.h"
 #include "Rtt_BitmapUtils.h"
 #include <SDL2/SDL.h>
+#include <cctype>
+#include <cstring>
 
 #if defined(EMSCRIPTEN)
 #include "emscripten/emscripten.h"		// for native alert and etc
@@ -171,14 +173,24 @@ namespace Rtt
 	{
 		Rtt_ASSERT(fData == NULL);
 
-		// get file ext
-		int n = strlen(path);
-		if (n < 5)
+		if (path == NULL)
 		{
 			return false;
 		}
 
-		std::string ext = path + n - 4;
+		// Extract extension after the last dot. Case-insensitive to accept .JPG, .PNG, etc.
+		const char *dot = strrchr(path, '.');
+		if (dot == NULL || dot[1] == '\0')
+		{
+			return false;
+		}
+
+		std::string ext(dot);
+		for (size_t i = 0; i < ext.size(); i++)
+		{
+			ext[i] = (char)tolower((unsigned char)ext[i]);
+		}
+
 		if (ext == ".bmp")
 		{
 			fData = bitmapUtil::loadBMP(path, fWidth, fHeight, fFormat);
@@ -202,7 +214,7 @@ namespace Rtt
 			}
 		}
 		else
-		if (ext == ".jpg")
+		if (ext == ".jpg" || ext == ".jpeg")
 		{
 			FILE* f = fopen(path, "rb");
 			if (f)

--- a/platform/emscripten/Rtt_EmscriptenPlatform.cpp
+++ b/platform/emscripten/Rtt_EmscriptenPlatform.cpp
@@ -294,13 +294,6 @@ namespace Rtt
 			}
 		}
 
-		if (result && result->GetFormat() == PlatformBitmap::kUndefined)
-		{
-			// failed to load bitmap
-			Rtt_DELETE(result);
-			result = NULL;
-		}
-
 		return result;
 	}
 

--- a/platform/shared/Rtt_BitmapUtils.cpp
+++ b/platform/shared/Rtt_BitmapUtils.cpp
@@ -26,6 +26,12 @@ namespace bitmapUtil
 	};
 	typedef struct JpegErrorMgr* jpegErrorMgr;
 
+	// Replace libpng's default error handler, which crashes on emscripten, with a clean longjmp.
+	void pngErrorHandler(png_structp png_ptr, png_const_charp)
+	{
+		longjmp(png_jmpbuf(png_ptr), 1);
+	}
+
 	void jpgErrorHandler(j_common_ptr cinfo)
 	{
 		char jpegLastErrorMsg[JMSG_LENGTH_MAX];
@@ -246,7 +252,7 @@ namespace bitmapUtil
 
 	uint8_t* loadPNG(FILE* fp, int& w, int& h)
 	{
-		png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+		png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, pngErrorHandler, NULL);
 		if (png == NULL)
 		{
 			return NULL;
@@ -255,11 +261,13 @@ namespace bitmapUtil
 		png_infop info = png_create_info_struct(png);
 		if (info == NULL)
 		{
+			png_destroy_read_struct(&png, NULL, NULL);
 			return NULL;
 		}
 
 		if (setjmp(png_jmpbuf(png)))
 		{
+			png_destroy_read_struct(&png, &info, NULL);
 			return NULL;
 		}
 


### PR DESCRIPTION
Currently HTML5 builds crash if they handle .jpg/.jpeg images. Additionally, while I was testing the [Add display.isValidObject function](https://github.com/coronalabs/corona/pull/908) feature, I found that HTML5 builds detect invalid/corrupted image files, but instead of just logging an error, like on other platforms, they just crash.

- Commit f45abe2076261a89ef4866325492ed61a1a82bf8 resolves https://github.com/coronalabs/corona/issues/875, which was caused by improper file extension handling/getting.
- Commit 3d3824988d469a54c68d51573510aab204f8768d adds proper error handling for invalid/corrupted image files and prevents the app from crashing when loading such files.

---

The sample project contains 6 valid image files and 16 invalid/corrupted image files. It'll work with these changes, but instantly crash on current HTML5 builds:

**[html5-build-errors.zip](https://github.com/user-attachments/files/28704248/html5-build-errors.zip)**
