### PR TITLE
HTML5: Fix "down" phase never triggering for escape key

### DIFF
--- a/platform/emscripten/Rtt_EmscriptenContext.cpp
+++ b/platform/emscripten/Rtt_EmscriptenContext.cpp
@@ -884,13 +884,6 @@ namespace Rtt
 		}
 		case SDL_KEYDOWN:
 		{
-			SDL_Keycode	key = event.key.keysym.sym;
-			if (key == SDLK_ESCAPE)
-			{
-				event.type = SDL_QUIT;
-				return true;		// close app
-			}
-			
 			// ignore key repeat
 			if (event.key.repeat == 0)
 			{


### PR DESCRIPTION
- Remove the special case that turned escape's keydown into a quit event and returned early, skipping the "down" phase in Lua. Escape now delivers both phases like every other key, matching other platforms' behaviour.
- The old quit path was already a no-op on HTML5 (Emscripten ignores the close-app return), so browser behavior is unchanged. This was probably an old leftover from HTML5 early beta days.