### PR TITLE
Windows: enable mouse events in Simulator on all skins

### DIFF
--- a/platform/linux/src/Rtt_LinuxDevice.cpp
+++ b/platform/linux/src/Rtt_LinuxDevice.cpp
@@ -61,6 +61,7 @@ namespace Rtt
 		case MPlatformDevice::kHeadingEvent:
 		case MPlatformDevice::kMultitouchEvent:
 		case MPlatformDevice::kKeyEvent:
+		case MPlatformDevice::kMouseEvent:
 		case MPlatformDevice::kAccelerometerEvent:
 			hasEventSource = true;
 			break;

--- a/platform/mac/Rtt_MacDevice.mm
+++ b/platform/mac/Rtt_MacDevice.mm
@@ -421,11 +421,11 @@ MacDevice::HasEventSource( EventType type ) const
 		case MPlatformDevice::kGyroscopeEvent:
 		case MPlatformDevice::kMultitouchEvent:
 		case MPlatformDevice::kHeadingEvent:
-		case MPlatformDevice::kMouseEvent:
 			hasEventSource = false;
 			break;
 		case MPlatformDevice::kLocationEvent:
 		case MPlatformDevice::kKeyEvent:
+		case MPlatformDevice::kMouseEvent:
 		case MPlatformDevice::kInputDeviceStatusEvent:
 			hasEventSource = true;
 			break;

--- a/platform/resources/init.lua
+++ b/platform/resources/init.lua
@@ -344,17 +344,17 @@ Runtime._proxy =
 
 local needsHardwareSupport = { orientation=true, accelerometer=true, gyroscope=true, location=true, heading=true }
 
-function Runtime:addEventListener( eventName, listener )
+function Runtime:addEventListener( eventName, listener, suppressSimulatorWarning )
 	local super = self._super
 	local noListeners = not self:respondsToEvent( eventName )
 	local wasAdded = super.addEventListener( self, eventName, listener )
 
-	-- If a "key" event listener is installed on a simulated iOS/tvOS/WinPhone device,
-	-- warn it wont be effective on a real device
-	if eventName and eventName == "key" and system.getInfo("environment") == "simulator" then
+	-- If a "key" or "mouse" listener is added on a simulated iOS/tvOS/WinPhone device, warn it won't
+	-- fire on a real device. The Simulator's own internal mouse listener passes suppressSimulatorWarning.
+	if not suppressSimulatorWarning and eventName and (eventName == "key" or eventName == "mouse") and system.getInfo("environment") == "simulator" then
 		local osName = system.getInfo("platform")
 		if osName == "ios" or osName == "tvos" or osName == "winphone" then
-			print("WARNING: Runtime:addEventListener: real "..osName.." devices don't generate 'key' events")
+			print("WARNING: Runtime:addEventListener: real "..osName.." devices don't generate '"..eventName.."' events")
 		end
 	end
 

--- a/platform/shared/Rtt_PlatformSimulator.cpp
+++ b/platform/shared/Rtt_PlatformSimulator.cpp
@@ -371,9 +371,14 @@ PlatformSimulator::LoadConfig( const char deviceConfigFile[], Config& rConfig )
 		rConfig.supportsMouse = false;
 		switch (rConfig.platform)
 		{
+			// In the Simulator we allow mouse events in all skins though we
+			// warn if the simulated device doesn't support them (see init.lua)
 			case TargetDevice::kAndroidPlatform:
+			case TargetDevice::kIPhonePlatform:
 			case TargetDevice::kOSXPlatform:
+			case TargetDevice::kTVOSPlatform:
 			case TargetDevice::kWin32Platform:
+			case TargetDevice::kWinPhoneSilverlightPlatform:
 				rConfig.supportsMouse = true;
 				break;
 			default:

--- a/platform/windows/Corona.Native.Library.Win32/Interop/LuaMethodCallback.h
+++ b/platform/windows/Corona.Native.Library.Win32/Interop/LuaMethodCallback.h
@@ -231,13 +231,16 @@ class LuaMethodCallback
 
 		  @param eventName The name of the event, such as "enterFrame".
 
+		  @param suppressSimulatorWarning When true, Runtime:addEventListener skips its warning that the
+		  simulated device would not generate this event on real hardware (used for Simulator-internal listeners).
+
 		  @return
 		  Returns true if the Lua Runtime function was successfully called.
 		
 		  Returns false if given a null "eventName" argument, if this callback's Lua function is no longer registered,
 		  or if failed to access the Lua Runtime object.
 		 */
-		bool AddToRuntimeEventListeners(const char* eventName)
+		bool AddToRuntimeEventListeners(const char* eventName, bool suppressSimulatorWarning = false)
 		{
 			// Validate.
 			if (!fLuaStatePointer || !eventName || (LUA_NOREF == fLuaRegistryReferenceId))
@@ -262,7 +265,10 @@ class LuaMethodCallback
 			lua_insert(fLuaStatePointer, -2);
 			lua_pushstring(fLuaStatePointer, eventName);
 			lua_rawgeti(fLuaStatePointer, LUA_REGISTRYINDEX, fLuaRegistryReferenceId);
-			CoronaLuaDoCall(fLuaStatePointer, 3, 0);
+			// 4th arg lets Runtime:addEventListener suppress its simulated-device warning for this
+			// internally-added listener (see init.lua).
+			lua_pushboolean(fLuaStatePointer, suppressSimulatorWarning ? 1 : 0);
+			CoronaLuaDoCall(fLuaStatePointer, 4, 0);
 			return true;
 		}
 

--- a/platform/windows/Corona.Simulator/Interop/SimulatorRuntimeEnvironment.cpp
+++ b/platform/windows/Corona.Simulator/Interop/SimulatorRuntimeEnvironment.cpp
@@ -310,7 +310,8 @@ void SimulatorRuntimeEnvironment::OnRuntimeLoaded(RuntimeEnvironment& sender, co
 
 	// Add Lua event listeners.
 	fLuaMouseEventCallback.RegisterTo(sender.GetRuntime()->VMContext().L());
-	fLuaMouseEventCallback.AddToRuntimeEventListeners("mouse");
+	// true: this is the Simulator's own listener, so don't warn about the simulated device (see init.lua).
+	fLuaMouseEventCallback.AddToRuntimeEventListeners("mouse", true);
 }
 
 void SimulatorRuntimeEnvironment::OnRuntimeTerminating(RuntimeEnvironment& sender, const EventArgs& arguments)


### PR DESCRIPTION
I've spent too many hours on Windows debugging why mouse events weren't firing only to remember that I was simulating an iOS device. 😅 Currently adding mouse events just fails silently on Simulator, but key events work just fine and they just give out a warning when simulating unsupported devices, so I replicated that behaviour for mouse events.

## Changes
- Add iOS/tvOS/WinPhone to the Simulator's supportsMouse config so mouse events fire on those skins (they were blocked on Windows), matching how key events already warn-and-fire
  - Just adding Windows Phone here since the option exists in the Simulator (in case some poor soul selects it)
- Extend the init.lua simulated-device warning to cover "mouse" as well as "key", reminding devs the events won't fire on a real devices
- Report mouse as an available event source on macOS and Linux so Runtime:hasEventSource("mouse") returns true instead of returning false / asserting in debug
- Also adding a third optional suppressSimulatorWarning parameter to Runtime:addEventListener to suppress "key" and "mouse" warnings on the Simulator
  - Making the Simulator's/Welcome Screen's own internal mouse-cursor listener suppress warnings so it won't fire every time when simulating unsupported devices/skins

## To test
Create an empty projects and just copy this to main.lua. Then run the project on the Simulator while simulating iOS, tvOS or Windows Phone device.
```lua
-- Called when a mouse event has been received.
local function onMouseEvent( event )
	if event.type == "down" then
		if event.isPrimaryButtonDown then
			print( "Left mouse button clicked." )
		elseif event.isSecondaryButtonDown then
			print( "Right mouse button clicked." )        
		end
	end
end

-- Add the mouse event listener.
Runtime:addEventListener( "mouse", onMouseEvent )

-- Optionally, suppress the warning on the Simulator.
-- Runtime:addEventListener( "mouse", onMouseEvent, true )
``` 