### PR TITLE
Remove jarsigner timestamp from keystore check

### DIFF
--- a/platform/mac/AndroidAppBuildController.mm
+++ b/platform/mac/AndroidAppBuildController.mm
@@ -895,54 +895,6 @@ static NSString *kChooseFromFollowing = @"Choose from the following…";
 	platformServices->Platform().PathForFile( NULL, Rtt::MPlatform::kResourceDir, Rtt::MPlatform::kDefaultPathFlags, resourcesDir );
 
 	return listKeyStore.AreKeyStoreAndAliasPasswordsValid(keyStore, keyPW, alias, aliasPW, resourcesDir.GetString());
-
-#if 0
-	Rtt::String resourcesDir;
-
-	self.authorizer->GetServices().Platform().PathForFile( NULL, Rtt::MPlatform::kResourceDir, Rtt::MPlatform::kDefaultPathFlags, resourcesDir );
-
-	NSString *resourceDir = [NSString stringWithExternalString:resourcesDir.GetString()];
-//	NSString *buildFilePath = [resourceDir stringByAppendingPathComponent:@"build.xml"];
-	NSString *tmpDir = NSTemporaryDirectory();
-	NSString *srcTestJar = [resourceDir stringByAppendingPathComponent:@"_coronatest.jar"];
-	NSString *dstTestJar = [tmpDir stringByAppendingPathComponent:@"_coronatest.jar"];
-
-// Escape quotes in the strings by replacing single quotes with "'\''" and then enclosing in single quotes when we build the command
-    NSString *keyStoreStr = [[NSString stringWithExternalString:keyStore] stringByReplacingOccurrencesOfString:@"'" withString:@"'\''"];
-    NSString *keyPWStr = [[NSString stringWithExternalString:keyPW] stringByReplacingOccurrencesOfString:@"'" withString:@"'\''"];
-    NSString *aliasStr = [[NSString stringWithExternalString:alias] stringByReplacingOccurrencesOfString:@"'" withString:@"'\''"];
-    NSString *aliasPWStr = [[NSString stringWithExternalString:aliasPW] stringByReplacingOccurrencesOfString:@"'" withString:@"'\''"];
-    
-	NSString *script = [[NSString alloc] initWithFormat:
-		@"cp -f '%@' '%@'; JAVA_TOOL_OPTIONS='-Duser.language=en' jarsigner -tsa http://timestamp.digicert.com -keystore '%@' -storepass '%@' -keypass '%@' '%@' '%@'; exit $?",
-		srcTestJar, tmpDir, keyStoreStr, keyPWStr, aliasPWStr, dstTestJar, aliasStr];
-
-//	NSLog( @"tmp dir(%@)", tmpDir );
-//	NSLog( @"<script>\n%@\n</script>", script ); 
-
-    // The command we run to test the password emits the string "jar signed", this makes that look sensible
-    printf("Testing credentials for '%s': ", keyStore);
-
-	NSArray *arguments = [[NSArray alloc] initWithObjects:@"-c", script, nil];
-	[script release];
-
-	NSTask* task = [[NSTask alloc] init];
-	[task setLaunchPath:@"/bin/sh"];
-	[task setArguments:arguments];
-	[arguments release];
-//	NSFileHandle* devNull = [NSFileHandle fileHandleWithNullDevice];
-//	[task setStandardOutput:devNull];
-//	[task setStandardError:devNull];
-	[task launch];
-	[task waitUntilExit];
-	int exitCode = [task terminationStatus];
-//	[task setStandardOutput:[NSFileHandle fileHandleWithStandardOutput]];
-//	[task setStandardError:[NSFileHandle fileHandleWithStandardOutput]];
-	[task release];
-//	Rtt_TRACE_SIM( ( "ERROR: Failed to verify alias password.  Error code(%d)\n", exitCode ) );
-//	NSLog( @"alias password.  exit code(%d)\n", exitCode );
-	return ( 0 == exitCode );
-#endif
 }
 
 - (NSString*)appExtension

--- a/platform/shared/ListKeyStore.cpp
+++ b/platform/shared/ListKeyStore.cpp
@@ -353,7 +353,7 @@ ListKeyStore::AreKeyStoreAndAliasPasswordsValid( const char *keyStore, const cha
 
 #if defined(Rtt_MAC_ENV) || defined(Rtt_LINUX_ENV)
 
-	const char kCmdFormat[] = "JAVA_TOOL_OPTIONS='-Duser.language=en' /usr/bin/jarsigner -tsa http://timestamp.digicert.com -keystore %s -storepass %s -keypass %s %s %s; exit $?";
+	const char kCmdFormat[] = "JAVA_TOOL_OPTIONS='-Duser.language=en' /usr/bin/jarsigner -keystore %s -storepass %s -keypass %s %s %s; exit $?";
 
 	snprintf(cmdBuf, sizeof(cmdBuf), kCmdFormat, keyStoreStr.c_str(), keyPWStr.c_str(), aliasPWStr.c_str(), dstTestJarStr.c_str(), aliasStr.c_str() );
 
@@ -367,7 +367,7 @@ ListKeyStore::AreKeyStoreAndAliasPasswordsValid( const char *keyStore, const cha
 	keytoolPath = jdkPath + "\\bin\\jarsigner.exe";
 	_putenv_s("JAVA_TOOL_OPTIONS", "-Duser.language=en");
 
-	const char kCmdFormat[] = "\"%s\" -tsa http://timestamp.digicert.com -keystore %s -storepass %s -keypass %s %s %s";
+	const char kCmdFormat[] = "\"%s\" -keystore %s -storepass %s -keypass %s %s %s";
 
 	snprintf(cmdBuf, sizeof(cmdBuf), kCmdFormat, keytoolPath.c_str(), keyStoreStr.c_str(), keyPWStr.c_str(), aliasPWStr.c_str(), dstTestJarStr.c_str(), aliasStr.c_str() );
 


### PR DESCRIPTION
Solar2D's Android keystore credential check (ListKeyStore::AreKeyStoreAndAliasPasswordsValid) runs jarsigner with a hardcoded `-tsa http://timestamp.digicert.com` to sign a throwaway _coronatest.jar, purely to confirm the keystore and alias passwords are valid. The timestamp serves no purpose and the signed jar is discarded immediately.

The real APK/AAB is signed by Gradle with no timestamp authority configured at all. Android and Google Play do not require a signature timestamp. The only effect of the flag is to add a network round-trip to DigiCert to an otherwise fully offline password check, and when that host is unreachable (due to connection issues, geoblocking, etc.) the check fails and the Simulator reports a misleading "The password for the alias was not valid, or the Java JDK was not found."

This PR removes the `-tsa` argument from both jarsigner command strings (the Mac/Linux and Windows branches). jarsigner signs fine without it (it prints a "no timestamp" warning and still exits 0), so a valid keystore still validates and a wrong password still fails. **The shipped artifact is unchanged because it was never timestamped to begin with**. The change also deletes a dead `#if 0` block in AndroidAppBuildController.mm that held a superseded inline copy of the same check.

I have tested this on Solar2D Simulator on Windows and it works as intended. 

---

**Changes:**
- Drop the hardcoded `-tsa http://timestamp.digicert.com` from both jarsigner commands in the Android keystore credential check, making the check fully offline
- Fixes the misleading "password not valid, or JDK not found" failure when the timestamp host is unreachable. The test jar is discarded anyway and Gradle already signs the real APK/AAB with no timestamp, so shipped apps are unaffected
- Remove the dead `#if 0` jarsigner block in AndroidAppBuildController.mm (a superseded inline copy of the same check)