### PR TITLE
Core: fix mesh bounds after setVertex updates

### DIFF
--- a/librtt/Display/Rtt_ShapeAdapterMesh.cpp
+++ b/librtt/Display/Rtt_ShapeAdapterMesh.cpp
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 // This file is part of the Corona game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -602,11 +603,16 @@ int ShapeAdapterMesh::setVertex( lua_State *L )
     }
 
 	Vertex2& orig = tesselator->GetMesh().WriteAccess()[vertIndex];
-	
-    if( !Rtt_RealEqual(x, orig.x) || !Rtt_RealEqual(y, orig.y) || zChanged)
+
+	bool xyChanged = !Rtt_RealEqual( x, orig.x ) || !Rtt_RealEqual( y, orig.y );
+	if ( xyChanged || zChanged )
 	{
-		orig.x = x;
-		orig.y = y;
+		if ( xyChanged )
+		{
+			orig.x = x;
+			orig.y = y;
+			tesselator->Invalidate();
+		}
 
 		path->Invalidate( ClosedPath::kFillSource |
 						 ClosedPath::kStrokeSource );


### PR DESCRIPTION
This prevents resized meshes from being culled using stale bounds near screen edges.

This PR invalidates the cached bounds when x or y changes. Z-only updates do not rebuild the 2D bounds, and values within the existing floating-point tolerance remain ignored.
Tested with an [edge-culling.tar.gz](https://github.com/user-attachments/files/30450742/edge-culling.tar.gz) sample comparing a rectangle, an unchanged mesh, and a resized mesh.

| BEFORE FIX | AFTER FIX |
|:------:|:-----:|
| <img width="300" alt="before fix" src="https://github.com/user-attachments/assets/8ac42d66-aefe-40f2-aad5-1bb839458e04" /> | <img width="300" alt="after fix" src="https://github.com/user-attachments/assets/c2685230-c575-42fb-9b18-168b92df8c24" /> |
